### PR TITLE
Typo in compiller method getCompiledPath => getCompiledTemplatePath

### DIFF
--- a/en/reference/volt.rst
+++ b/en/reference/volt.rst
@@ -1439,7 +1439,7 @@ Using Volt in a stand-alone mode can be demonstrated below:
     $compiler->compile('layouts/main.volt');
 
     //Require the compiled templated (optional)
-    require $compiler->getCompiledPath();
+    require $compiler->getCompiledTemplatePath();
 
 External Resources
 ------------------


### PR DESCRIPTION
Typo in compiller method getCompiledPath => getCompiledTemplatePath
