### PR TITLE
Change setEncryption to useEncryption

### DIFF
--- a/en/reference/cookies.rst
+++ b/en/reference/cookies.rst
@@ -50,7 +50,7 @@ You can disable encryption in the following way:
 
     $di->set('cookies', function() {
         $cookies = new Phalcon\Http\Response\Cookies();
-        $cookies->setEncryption(false);
+        $cookies->useEncryption(false);
         return $cookies;
     });
 


### PR DESCRIPTION
Tested under 1.2.3 Phalcon\Http\Response\Cookies doesn't have setEncryption method,

CMIIW
