### PR TITLE
Fixing typo for Phalcon Developer tools

### DIFF
--- a/en/reference/tools.rst
+++ b/en/reference/tools.rst
@@ -90,7 +90,7 @@ Change the database section in your config.ini file:
     host     = "127.0.0.1"
     username = "root"
     password = "secret"
-    name     = "store_db"
+    dbname   = "store_db"
 
     [phalcon]
     controllersDir = "../app/controllers/"


### PR DESCRIPTION
Hi Team Phalcon,

I have been developing some of my project using Phalcon.
And I think the framework is great and very interesting to me.

So today, I found the typo in the tools.rst file.
Actually it was only one word but it is so important, I think.

If we write current "config.ini", "phalcon migration generate" command doesn't work properly. I have just tried it.

So it would be great if you could make sure what I reviewed.
Thanks
