### PR TITLE
Fix background color for documentation header.

### DIFF
--- a/en/_static/docs.css
+++ b/en/_static/docs.css
@@ -641,7 +641,7 @@ blockquote {
 .header-line {
     min-width: 980px;
     height: 87px;
-    background: #5da49e url('img/header-line.jpg') 50% 0 no-repeat;
+    background: #42AAA9 url('img/header-line.jpg') 50% 0 no-repeat;
     margin: 0 0 20px;
     overflow: hidden;
 }

--- a/fr/_static/docs.css
+++ b/fr/_static/docs.css
@@ -638,7 +638,7 @@ blockquote {
 .header-line {
     min-width: 980px;
     height: 87px;
-    background: #5da49e url('img/header-line.jpg') 50% 0 no-repeat;
+    background: #42AAA9 url('img/header-line.jpg') 50% 0 no-repeat;
     margin: 0 0 20px;
     overflow: hidden;
 }

--- a/ja/_static/docs.css
+++ b/ja/_static/docs.css
@@ -638,7 +638,7 @@ blockquote {
 .header-line {
     min-width: 980px;
     height: 87px;
-    background: #5da49e url('img/header-line.jpg') 50% 0 no-repeat;
+    background: #42AAA9 url('img/header-line.jpg') 50% 0 no-repeat;
     margin: 0 0 20px;
     overflow: hidden;
 }

--- a/pl/_static/docs.css
+++ b/pl/_static/docs.css
@@ -638,7 +638,7 @@ blockquote {
 .header-line {
     min-width: 980px;
     height: 87px;
-    background: #5da49e url('img/header-line.jpg') 50% 0 no-repeat;
+    background: #42AAA9 url('img/header-line.jpg') 50% 0 no-repeat;
     margin: 0 0 20px;
     overflow: hidden;
 }

--- a/pt/_static/docs.css
+++ b/pt/_static/docs.css
@@ -638,7 +638,7 @@ blockquote {
 .header-line {
     min-width: 980px;
     height: 87px;
-    background: #5da49e url('img/header-line.jpg') 50% 0 no-repeat;
+    background: #42AAA9 url('img/header-line.jpg') 50% 0 no-repeat;
     margin: 0 0 20px;
     overflow: hidden;
 }

--- a/ru/_static/docs.css
+++ b/ru/_static/docs.css
@@ -638,7 +638,7 @@ blockquote {
 .header-line {
     min-width: 980px;
     height: 87px;
-    background: #5da49e url('img/header-line.jpg') 50% 0 no-repeat;
+    background: #42AAA9 url('img/header-line.jpg') 50% 0 no-repeat;
     margin: 0 0 20px;
     overflow: hidden;
 }


### PR DESCRIPTION
This changes background color surrounding header-line.jpg so that it matches the image.

You can clearly see the difference in this picture:

![header-line](https://f.cloud.github.com/assets/1296882/2206456/e7098400-9961-11e3-86e4-9736264c8da6.jpg)
