### PR TITLE
Example of using findFirst() is broken

### DIFF
--- a/en/reference/odm.rst
+++ b/en/reference/odm.rst
@@ -194,8 +194,10 @@ Both find() and findFirst() methods accept an associative array specifying the s
 
     // First robot where type = "mechanical" and year = "1999"
     $robot = Robots::findFirst(array(
-        "type" => "mechanical",
-        "year" => "1999"
+        "conditions" => array(
+            "type" => "mechanical",
+            "year" => "1999"
+        )
     ));
 
     // All virtual robots ordered by name downward


### PR DESCRIPTION
This `findFirst()` example seems to not work: the search conditions have to be wrapped in an array instead being passed directly to the function.
