### PR TITLE
Resolve Issue #357

### DIFF
--- a/en/reference/volt.rst
+++ b/en/reference/volt.rst
@@ -701,7 +701,7 @@ More examples:
     {% for key, name in [1: 'Voltron', 2: 'Astroy Boy', 3: 'Bender'] %}
         {% if key is even %}
             {{ name }}
-        {% endif }
+        {% endif %}
     {% endfor %}
 
     {% for key, name in [1: 'Voltron', 2: 'Astroy Boy', 3: 'Bender'] %}


### PR DESCRIPTION
## Missing volt ending tags in volt.rst

Touched each instance of "{%" to make sure that all opening tabs have
their corresponding closing tags.
