### PR TITLE
add how to connect mysql via unix socket

### DIFF
--- a/en/api/Phalcon_Db_Adapter_Pdo.rst
+++ b/en/api/Phalcon_Db_Adapter_Pdo.rst
@@ -21,7 +21,7 @@ Phalcon\\Db\\Adapter\\Pdo is the Phalcon\\Db that internally uses PDO to connect
 
     //or connect via unix socket
     $connection = new Phalcon\Db\Adapter\Pdo\Mysql(array(
-        'dsn' => 'mysql:dbname=YOUR_DB_NAME;unix_socket=/PATH/TO/SOCK_FILE;charset=utf8;',
+        'dsn' => 'mysql:unix_socket=/PATH/TO/SOCK_FILE;dbname=YOUR_DB_NAME;charset=utf8;',
         'username' => 'YOUR_USERNAME',
         'password' => 'YOUR_PASSWORD',
     ));


### PR DESCRIPTION
the pdo library is support dsn options, but the document didn't have any message about that.
some people may need to connect mysql via unix socket. so i add the dsn and usage, maybe it will help more people.
