### PR TITLE
Improvement of reserve example in queueing

### DIFF
--- a/en/reference/queue.rst
+++ b/en/reference/queue.rst
@@ -97,9 +97,7 @@ jobs must be "reserved" so other workers don't re-process them while other worke
 
     <?php
 
-    while ($queue->peekReady() !== false) {
-
-        $job = $queue->reserve();
+    while (($job = $queue->reserve())) {
 
         $message = $job->getBody();
 


### PR DESCRIPTION
Since both 'peek' and 'reserve' commands return job data, it seems to be more logical and efficient to only use reserve.
See https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt#L238
