### PR TITLE
Small explanation with two php blocks break

### DIFF
--- a/en/reference/validation.rst
+++ b/en/reference/validation.rst
@@ -66,6 +66,8 @@ You can put your validations in a separate file for better re-use code and organ
         }
     }
 
+Then initialize and use your own validator:
+
 .. code-block:: php
 
     <?php


### PR DESCRIPTION
The two php blocks were too close together, as can be seen in the http://docs.phalconphp.com/en/latest/reference/validation.html documentation page. Note that this is not visible in github's Preview. With the added explanation, they are also separated, so double benefit from a simple edit.
