### PR TITLE
Update web_root to public

### DIFF
--- a/en/reference/built-in.rst
+++ b/en/reference/built-in.rst
@@ -19,11 +19,11 @@ If you want to rewrite the URIs to the index.php file use the following router f
     }
     return false;
 
-and then start the server with:
+and then start the server from the base project directory with:
 
 .. code-block:: bash
 
-    php -S localhost:8000 -t /web_root .htrouter.php
+    php -S localhost:8000 -t /public .htrouter.php
 
 Then point your browser to http://localhost:8000/ to check if everything is working.
 


### PR DESCRIPTION
web_root is confusing and may lead people to think they should use the project base directory. Since the built-in PHP web server doesn't recognize htaccess files, it needs to use the /public directory instead.
