### PR TITLE
Update volt form example to use end_form() and added for attr to labels

### DIFF
--- a/en/reference/volt.rst
+++ b/en/reference/volt.rst
@@ -804,15 +804,15 @@ Volt is highly integrated with :doc:`Phalcon\\Tag <tags>`, so it's easy to use t
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 The following PHP is generated:
 
@@ -822,15 +822,15 @@ The following PHP is generated:
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 To call a Phalcon\\Tag helper, you only need to call an uncamelized version of the method:
 

--- a/es/reference/volt.rst
+++ b/es/reference/volt.rst
@@ -703,15 +703,15 @@ Volt is highly integrated with :doc:`Phalcon\\Tag <tags>`, so it's easy to use t
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 The following PHP is generated:
 
@@ -721,15 +721,15 @@ The following PHP is generated:
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 To call a Phalcon\Tag helper, you only need to call an uncamelized version of the method:
 

--- a/fr/reference/volt.rst
+++ b/fr/reference/volt.rst
@@ -803,15 +803,15 @@ Volt is highly integrated with :doc:`Phalcon\\Tag <tags>`, so it's easy to use t
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 The following PHP is generated:
 
@@ -821,15 +821,15 @@ The following PHP is generated:
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 To call a Phalcon\\Tag helper, you only need to call an uncamelized version of the method:
 

--- a/ja/reference/volt.rst
+++ b/ja/reference/volt.rst
@@ -803,15 +803,15 @@ Volt is highly integrated with :doc:`Phalcon\\Tag <tags>`, so it's easy to use t
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 The following PHP is generated:
 
@@ -821,15 +821,15 @@ The following PHP is generated:
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 To call a Phalcon\\Tag helper, you only need to call an uncamelized version of the method:
 

--- a/pl/reference/volt.rst
+++ b/pl/reference/volt.rst
@@ -804,15 +804,15 @@ Volt is highly integrated with :doc:`Phalcon\\Tag <tags>`, so it's easy to use t
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 The following PHP is generated:
 
@@ -822,15 +822,15 @@ The following PHP is generated:
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 To call a Phalcon\\Tag helper, you only need to call an uncamelized version of the method:
 

--- a/pt/reference/volt.rst
+++ b/pt/reference/volt.rst
@@ -803,15 +803,15 @@ Volt is highly integrated with :doc:`Phalcon\\Tag <tags>`, so it's easy to use t
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 The following PHP is generated:
 
@@ -821,15 +821,15 @@ The following PHP is generated:
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 To call a Phalcon\\Tag helper, you only need to call an uncamelized version of the method:
 

--- a/ru/reference/volt.rst
+++ b/ru/reference/volt.rst
@@ -795,15 +795,15 @@ Volt сильно связан с  :doc:`Phalcon\\Tag <tags>`, поэтому м
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 В результате будет сгенерирован следующий PHP-код:
 
@@ -813,15 +813,15 @@ Volt сильно связан с  :doc:`Phalcon\\Tag <tags>`, поэтому м
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 Для вызова Phalcon\Tag helper, вам необходимо лишь вызвать соответсвующие версии методов не в Camelcase:
 

--- a/zh/reference/volt.rst
+++ b/zh/reference/volt.rst
@@ -804,15 +804,15 @@ Volt is highly integrated with :doc:`Phalcon\\Tag <tags>`, so it's easy to use t
 
     {{ form('products/save', 'method': 'post') }}
 
-        <label>Name</label>
+        <label for="name">Name</label>
         {{ text_field("name", "size": 32) }}
 
-        <label>Type</label>
+        <label for="type">Type</label>
         {{ select("type", productTypes, 'using': ['id', 'name']) }}
 
         {{ submit_button('Send') }}
 
-    </form>
+    {{ end_form() }}
 
 The following PHP is generated:
 
@@ -822,15 +822,15 @@ The following PHP is generated:
 
     <?php echo Phalcon\Tag::form(array('products/save', 'method' => 'post')); ?>
 
-        <label>Name</label>
+        <label for="name">Name</label>
         <?php echo Phalcon\Tag::textField(array('name', 'size' => 32)); ?>
 
-        <label>Type</label>
+        <label for="type">Type</label>
         <?php echo Phalcon\Tag::select(array('type', $productTypes, 'using' => array('id', 'name'))); ?>
 
         <?php echo Phalcon\Tag::submitButton('Send'); ?>
 
-    </form>
+    {{ end_form() }}
 
 To call a Phalcon\\Tag helper, you only need to call an uncamelized version of the method:
 


### PR DESCRIPTION
**Updates all language files**

Updates Volt form example to use `end_form()`. Also, the adding of the `for` attr to the label elements is mearly a semantic thing. The for element should be used, unless you wrap the input element within the label, which to me, is a little weird. 
