### PR TITLE
update deleteColumn() to dropColumn() to resolve issue #442

### DIFF
--- a/en/reference/db.rst
+++ b/en/reference/db.rst
@@ -747,7 +747,7 @@ is limited by these constraints.
     )));
 
     // Deleting the column "name"
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 Dropping Tables

--- a/es/reference/db.rst
+++ b/es/reference/db.rst
@@ -620,7 +620,7 @@ is limited by these constraints.
     );
 
     // Deleting the column "name"
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 Dropping Tables

--- a/fr/reference/db.rst
+++ b/fr/reference/db.rst
@@ -747,7 +747,7 @@ is limited by these constraints.
     )));
 
     // Deleting the column "name"
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 Dropping Tables

--- a/ja/reference/db.rst
+++ b/ja/reference/db.rst
@@ -747,7 +747,7 @@ is limited by these constraints.
     )));
 
     // Deleting the column "name"
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 テーブルの削除

--- a/pl/reference/db.rst
+++ b/pl/reference/db.rst
@@ -747,7 +747,7 @@ is limited by these constraints.
     )));
 
     // Deleting the column "name"
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 Dropping Tables

--- a/pt/reference/db.rst
+++ b/pt/reference/db.rst
@@ -747,7 +747,7 @@ is limited by these constraints.
     )));
 
     // Deleting the column "name"
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 Dropping Tables

--- a/ru/reference/db.rst
+++ b/ru/reference/db.rst
@@ -766,7 +766,7 @@ Phalcon\\Db поддерживает следующие типы столбцо�
     )));
 
     // Удаление столбца “name”
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 Удаление таблицы

--- a/zh/reference/db.rst
+++ b/zh/reference/db.rst
@@ -740,7 +740,7 @@ Phalcon\\Db 支持下面的数据库字段类型:
     )));
 
     // 删除名为"name"的字段
-    $connection->deleteColumn("robots", null, "name");
+    $connection->dropColumn("robots", null, "name");
 
 
 删除数据库表（Dropping Tables）


### PR DESCRIPTION
Updated incorrect method call in [Database Abstraction Layer](http://docs.phalconphp.com/en/latest/reference/db.html#altering-tables). Correct API is documented in http://phalcon-php-framework-documentation.readthedocs.org/en/latest/api/Phalcon_Db_Adapter_Pdo_Mysql.html. 
