### PR TITLE
Mentionning that HTML entities are escaped

### DIFF
--- a/en/reference/filter.rst
+++ b/en/reference/filter.rst
@@ -112,7 +112,7 @@ The following are the built-in filters provided by this component:
 +-----------+---------------------------------------------------------------------------+
 | Name      | Description                                                               |
 +===========+===========================================================================+
-| string    | Strip tags                                                                |
+| string    | Strip tags and escapes HTML entities, including single and double quotes. |
 +-----------+---------------------------------------------------------------------------+
 | email     | Remove all characters except letters, digits and !#$%&*+-/=?^_`{|}~@.[].  |
 +-----------+---------------------------------------------------------------------------+


### PR DESCRIPTION
The documentation makes no mention about the fact that the "string" filter escapes HTML entities. We discovered that when `&#39;` started to appear in our database.