### PR TITLE
Fixed typo in setPath method

### DIFF
--- a/en/api/Phalcon_Http_Cookie.rst
+++ b/en/api/Phalcon_Http_Cookie.rst
@@ -83,7 +83,7 @@ Returns the current expiration time
 
 public :doc:`Phalcon\\Http\\Cookie <Phalcon_Http_Cookie>`  **setPath** (*string* $path)
 
-Sets the cookie's expiration time
+Sets the cookie's path
 
 
 


### PR DESCRIPTION
Old value is "Sets the cookie’s expiration time" and it's same like  setExpiration method so it was probably copy paste.