### PR TITLE
Update unit-testing documentation

### DIFF
--- a/en/reference/unit-testing.rst
+++ b/en/reference/unit-testing.rst
@@ -23,14 +23,6 @@ or by manually adding it to composer.json:
   }
 
 
-Or if you don't have composer you can install phpunit via pear:
-
-.. code-block:: bash
-
-  pear config-set auto_discover 1
-  pear install pear.phpunit.de/PHPUnit
-
-
 Once phpunit is installed create a directory called 'tests' in your root directory:
 
 .. code-block:: bash

--- a/en/reference/unit-testing.rst
+++ b/en/reference/unit-testing.rst
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
   {
       "require-dev": {
-          "phpunit/phpunit": "3.7.*"
+          "phpunit/phpunit": "~4.5"
       }
   }
 

--- a/ja/reference/unit-testing.rst
+++ b/ja/reference/unit-testing.rst
@@ -18,18 +18,9 @@ or by manually adding it to composer.json:
 
   {
       "require-dev": {
-          "phpunit/phpunit": "3.7.*"
+          "phpunit/phpunit": "~4.5"
       }
   }
-
-
-Or if you don't have composer you can install phpunit via pear:
-
-.. code-block:: bash
-
-  pear config-set auto_discover 1
-  pear install pear.phpunit.de/PHPUnit
-
 
 Once phpunit is installed create a directory called 'tests' in your root directory:
 

--- a/pl/reference/unit-testing.rst
+++ b/pl/reference/unit-testing.rst
@@ -18,18 +18,9 @@ or by manually adding it to composer.json:
 
   {
       "require-dev": {
-          "phpunit/phpunit": "3.7.*"
+          "phpunit/phpunit": "~4.5"
       }
   }
-
-
-Or if you don't have composer you can install phpunit via pear:
-
-.. code-block:: bash
-
-  pear config-set auto_discover 1
-  pear install pear.phpunit.de/PHPUnit
-
 
 Once phpunit is installed create a directory called 'tests' in your root directory:
 

--- a/ru/reference/unit-testing.rst
+++ b/ru/reference/unit-testing.rst
@@ -18,18 +18,9 @@
 
   {
       "require-dev": {
-          "phpunit/phpunit": "3.7.*"
+          "phpunit/phpunit": "~4.5"
       }
   }
-
-
-Или, если у вас нет composer, можно установить с помощью pear PHPUnit:
-
-.. code-block:: bash
-
-  pear config-set auto_discover 1
-  pear install pear.phpunit.de/PHPUnit
-
 
 После установки PHPUnit ​​создайте директорию tests' в корне проекта:
 


### PR DESCRIPTION
* PEAR is no longer supported by phpunit (https://github.com/sebastianbergmann/phpunit/wiki/End-of-Life-for-PEAR-Installation-Method).
* Updated version of phpunit.