### PR TITLE
Updated Phalcon_Mvc_Model_Message

### DIFF
--- a/en/api/Phalcon_Mvc_Model_Message.rst
+++ b/en/api/Phalcon_Mvc_Model_Message.rst
@@ -16,12 +16,12 @@ Encapsulates validation info generated before save/delete records fails
     
         public function beforeSave()
         {
-          if (this->name == 'Peter') {
-            text = "A robot cannot be named Peter";
-            field = "name";
-            type = "InvalidValue";
-            message = new Message(text, field, type);
-            this->appendMessage(message);
+          if ($this->name == 'Peter') {
+            $text = "A robot cannot be named Peter";
+            $field = "name";
+            $type = "InvalidValue";
+            $message = new Message($text, $field, $type);
+            $this->appendMessage($message);
          }
        }
     

--- a/es/api/Phalcon_Mvc_Model_Message.rst
+++ b/es/api/Phalcon_Mvc_Model_Message.rst
@@ -16,12 +16,12 @@ Encapsulates validation info generated before save/delete records fails
     
         public function beforeSave()
         {
-          if (this->name == 'Peter') {
-            text = "A robot cannot be named Peter";
-            field = "name";
-            type = "InvalidValue";
-            message = new Message(text, field, type);
-            this->appendMessage(message);
+          if ($this->name == 'Peter') {
+            $text = "A robot cannot be named Peter";
+            $field = "name";
+            $type = "InvalidValue";
+            $message = new Message($text, $field, $type);
+            $this->appendMessage($message);
          }
        }
     

--- a/fr/api/Phalcon_Mvc_Model_Message.rst
+++ b/fr/api/Phalcon_Mvc_Model_Message.rst
@@ -16,12 +16,12 @@ Encapsulates validation info generated before save/delete records fails
     
         public function beforeSave()
         {
-          if (this->name == 'Peter') {
-            text = "A robot cannot be named Peter";
-            field = "name";
-            type = "InvalidValue";
-            message = new Message(text, field, type);
-            this->appendMessage(message);
+          if ($this->name == 'Peter') {
+            $text = "A robot cannot be named Peter";
+            $field = "name";
+            $type = "InvalidValue";
+            $message = new Message($text, $field, $type);
+            $this->appendMessage($message);
          }
        }
     

--- a/ja/api/Phalcon_Mvc_Model_Message.rst
+++ b/ja/api/Phalcon_Mvc_Model_Message.rst
@@ -16,12 +16,12 @@ Encapsulates validation info generated before save/delete records fails
     
         public function beforeSave()
         {
-          if (this->name == 'Peter') {
-            text = "A robot cannot be named Peter";
-            field = "name";
-            type = "InvalidValue";
-            message = new Message(text, field, type);
-            this->appendMessage(message);
+          if ($this->name == 'Peter') {
+            $text = "A robot cannot be named Peter";
+            $field = "name";
+            $type = "InvalidValue";
+            $message = new Message($text, $field, $type);
+            $this->appendMessage($message);
          }
        }
     

--- a/pl/api/Phalcon_Mvc_Model_Message.rst
+++ b/pl/api/Phalcon_Mvc_Model_Message.rst
@@ -16,12 +16,12 @@ Encapsulates validation info generated before save/delete records fails
     
         public function beforeSave()
         {
-          if (this->name == 'Peter') {
-            text = "A robot cannot be named Peter";
-            field = "name";
-            type = "InvalidValue";
-            message = new Message(text, field, type);
-            this->appendMessage(message);
+          if ($this->name == 'Peter') {
+            $text = "A robot cannot be named Peter";
+            $field = "name";
+            $type = "InvalidValue";
+            $message = new Message($text, $field, $type);
+            $this->appendMessage($message);
          }
        }
     

--- a/ru/api/Phalcon_Mvc_Model_Message.rst
+++ b/ru/api/Phalcon_Mvc_Model_Message.rst
@@ -16,12 +16,12 @@ Encapsulates validation info generated before save/delete records fails
     
         public function beforeSave()
         {
-          if (this->name == 'Peter') {
-            text = "A robot cannot be named Peter";
-            field = "name";
-            type = "InvalidValue";
-            message = new Message(text, field, type);
-            this->appendMessage(message);
+          if ($this->name == 'Peter') {
+            $text = "A robot cannot be named Peter";
+            $field = "name";
+            $type = "InvalidValue";
+            $message = new Message($text, $field, $type);
+            $this->appendMessage($message);
          }
        }
     

--- a/zh/api/Phalcon_Mvc_Model_Message.rst
+++ b/zh/api/Phalcon_Mvc_Model_Message.rst
@@ -16,12 +16,12 @@ Encapsulates validation info generated before save/delete records fails
     
         public function beforeSave()
         {
-          if (this->name == 'Peter') {
-            text = "A robot cannot be named Peter";
-            field = "name";
-            type = "InvalidValue";
-            message = new Message(text, field, type);
-            this->appendMessage(message);
+          if ($this->name == 'Peter') {
+            $text = "A robot cannot be named Peter";
+            $field = "name";
+            $type = "InvalidValue";
+            $message = new Message($text, $field, $type);
+            $this->appendMessage($message);
          }
        }
     


### PR DESCRIPTION
Inserted missing '$' symbols for the code examples with the Phalcon_Mvc_Model_Message documentation.