### PR TITLE
Corrected typo for (en) models documentation

### DIFF
--- a/en/reference/models.rst
+++ b/en/reference/models.rst
@@ -1177,7 +1177,7 @@ A virtual foreign key can be set up to allow null values as follows:
         {
             $this->belongsTo("parts_id", "Parts", "id", array(
                 "foreignKey" => array(
-                    "allowNull" => true,
+                    "allowNulls" => true,
                     "message" => "The part_id does not exist on the Parts model"
                 )
             ));


### PR DESCRIPTION
Documentation was specifying 'allowNull' for allowing null values when it should have been 'allowNulls' - according to https://github.com/phalcon/cphalcon/blob/master/ext/phalcon/mvc/model.zep.c#L2178