### PR TITLE
Do not use costly Nginx variables to store static strings

### DIFF
--- a/en/reference/nginx.rst
+++ b/en/reference/nginx.rst
@@ -22,8 +22,7 @@ Using $_GET['_url'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -44,7 +43,7 @@ Using $_GET['_url'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -63,8 +62,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -80,7 +78,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -100,10 +98,8 @@ Dedicated Instance
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -132,7 +128,7 @@ Dedicated Instance
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -147,8 +143,7 @@ And this second configuration allow you to have different configurations by host
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -175,7 +170,7 @@ And this second configuration allow you to have different configurations by host
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/es/reference/nginx.rst
+++ b/es/reference/nginx.rst
@@ -22,8 +22,7 @@ Using $_GET['_url'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -44,7 +43,7 @@ Using $_GET['_url'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -63,8 +62,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -80,7 +78,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -100,10 +98,8 @@ Instancias dedicadas
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -132,7 +128,7 @@ Instancias dedicadas
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -147,8 +143,7 @@ Esta configuración te permite tener varias configuraciones por Host:
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -175,7 +170,7 @@ Esta configuración te permite tener varias configuraciones por Host:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/fr/reference/nginx.rst
+++ b/fr/reference/nginx.rst
@@ -22,8 +22,7 @@ Using $_GET['_url'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -44,7 +43,7 @@ Using $_GET['_url'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -63,8 +62,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -80,7 +78,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -100,10 +98,8 @@ Dedicated Instance
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -132,7 +128,7 @@ Dedicated Instance
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -147,8 +143,7 @@ And this second configuration allow you to have different configurations by host
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -175,7 +170,7 @@ And this second configuration allow you to have different configurations by host
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/ja/reference/nginx.rst
+++ b/ja/reference/nginx.rst
@@ -26,8 +26,7 @@ $_GET['_url'] をURIsとする場合:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -48,7 +47,7 @@ $_GET['_url'] をURIsとする場合:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -67,8 +66,7 @@ $_SERVER['REQUEST_URI'] をURIsとする場合:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -84,7 +82,7 @@ $_SERVER['REQUEST_URI'] をURIsとする場合:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -104,10 +102,8 @@ $_SERVER['REQUEST_URI'] をURIsとする場合:
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -136,7 +132,7 @@ $_SERVER['REQUEST_URI'] をURIsとする場合:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -151,8 +147,7 @@ $_SERVER['REQUEST_URI'] をURIsとする場合:
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -179,7 +174,7 @@ $_SERVER['REQUEST_URI'] をURIsとする場合:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/pl/reference/nginx.rst
+++ b/pl/reference/nginx.rst
@@ -22,8 +22,7 @@ Using $_GET['_url'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -44,7 +43,7 @@ Using $_GET['_url'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -63,8 +62,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -80,7 +78,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -100,10 +98,8 @@ Dedicated Instance
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -132,7 +128,7 @@ Dedicated Instance
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -147,8 +143,7 @@ And this second configuration allow you to have different configurations by host
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -175,7 +170,7 @@ And this second configuration allow you to have different configurations by host
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/pt/reference/nginx.rst
+++ b/pt/reference/nginx.rst
@@ -22,8 +22,7 @@ Utilizando $_GET['_url'] como fonte das URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -44,7 +43,7 @@ Utilizando $_GET['_url'] como fonte das URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -63,8 +62,7 @@ Utilizando $_SERVER['REQUEST_URI'] como fonte das URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -80,7 +78,7 @@ Utilizando $_SERVER['REQUEST_URI'] como fonte das URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -100,10 +98,8 @@ Instância Dedicada
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -132,7 +128,7 @@ Instância Dedicada
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -147,8 +143,7 @@ Esta segunda configuração permite você ter diferentes configurações por hos
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -175,7 +170,7 @@ Esta segunda configuração permite você ter diferentes configurações por hos
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/ru/reference/nginx.rst
+++ b/ru/reference/nginx.rst
@@ -22,8 +22,7 @@ Nginx_ это свободный, с открытым исходным кодо�
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -44,7 +43,7 @@ Nginx_ это свободный, с открытым исходным кодо�
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -63,8 +62,7 @@ Nginx_ это свободный, с открытым исходным кодо�
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -80,7 +78,7 @@ Nginx_ это свободный, с открытым исходным кодо�
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -100,10 +98,8 @@ Nginx_ это свободный, с открытым исходным кодо�
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -132,7 +128,7 @@ Nginx_ это свободный, с открытым исходным кодо�
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -147,8 +143,7 @@ Nginx_ это свободный, с открытым исходным кодо�
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -175,7 +170,7 @@ Nginx_ это свободный, с открытым исходным кодо�
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/transifex/base-rst/en/reference/nginx.rst
+++ b/transifex/base-rst/en/reference/nginx.rst
@@ -20,8 +20,7 @@
         server_name localhost.dev;
 
         index index.php index.html index.htm;
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -42,7 +41,7 @@
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -61,8 +60,7 @@
         server_name localhost.dev;
 
         index index.php index.html index.htm;
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -78,7 +76,7 @@
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -99,10 +97,8 @@
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -131,7 +127,7 @@
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 

--- a/zh/reference/nginx.rst
+++ b/zh/reference/nginx.rst
@@ -22,8 +22,7 @@ Using $_GET['_url'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         try_files $uri $uri/ @rewrite;
 
@@ -44,7 +43,7 @@ Using $_GET['_url'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -63,8 +62,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
 
         index index.php index.html index.htm;
 
-        set $root_path '/var/www/phalcon/public';
-        root $root_path;
+        root /var/www/phalcon/public;
 
         location / {
             try_files $uri $uri/ /index.php;
@@ -80,7 +78,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -100,10 +98,8 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
 
         #access_log  /var/log/nginx/host.access.log  main;
 
-        set $root_path '/srv/www/htdocs/phalcon-website/public';
-
         location / {
-            root   $root_path;
+            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
 
             # if file exists return it right away
@@ -132,7 +128,7 @@ Using $_SERVER['REQUEST_URI'] as source of URIs:
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /srv/www/htdocs/phalcon-website/public;
         }
     }
 
@@ -147,8 +143,7 @@ And this second configuration allow you to have different configurations by host
 
         server_name localhost;
 
-        set         $root_path '/var/www/$host/public';
-        root        $root_path;
+        root        /var/www/$host/public;
 
         access_log  /var/log/nginx/$host-access.log;
         error_log   /var/log/nginx/$host-error.log error;
@@ -175,7 +170,7 @@ And this second configuration allow you to have different configurations by host
         }
 
         location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root $root_path;
+            root /var/www/$host/public;
         }
 
         location ~ /\.ht {


### PR DESCRIPTION
> Variables should not be used as template macros. Variables are evaluated in the run-time during the processing of each request, so they are rather costly compared to plain static configuration. Using variables to store static strings is also a bad idea. Instead, a macro expansion and "include" directives should be used to generate configs more easily and it can be done with the external tools, e.g. sed + make or any other common template mechanism.