### PR TITLE
Synced install.rst, fixed some typos

### DIFF
--- a/en/reference/install.rst
+++ b/en/reference/install.rst
@@ -47,7 +47,7 @@ Specific packages for common platforms:
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -69,21 +69,24 @@ Add extension to your PHP configuration:
 
 .. code-block:: bash
 
-    # Suse: Add this line in your php.ini
+    # Suse: Add a file called phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    # CentOS/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
     extension=phalcon.so
 
-    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    # Ubuntu/Debian with apache2: Add a file called 30-phalcon.ini in /etc/php5/apache2/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    # Ubuntu/Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian with php5-cli: Add a file called 30-phalcon.ini in /etc/php5/cli/conf.d/ with this content:
     extension=phalcon.so
 
 Restart the webserver.
 
-If you are running Debian with php5-fpm, restart it:
+If you are running Ubuntu/Debian with php5-fpm, restart it:
 
 .. code-block:: bash
 

--- a/en/reference/install.rst
+++ b/en/reference/install.rst
@@ -43,7 +43,7 @@ Specific packages for common platforms:
 
 .. code-block:: bash
 
-    #Ubuntu
+    # Ubuntu
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
@@ -78,7 +78,7 @@ Add extension to your PHP configuration:
     # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/30-phalcon.ini with this content:
+    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
     extension=phalcon.so
 
 Restart the webserver.
@@ -131,8 +131,7 @@ Prerequisite packages are:
     sudo port install php55-phalcon
     sudo port install php56-phalcon
 
-Add extension to your PHP configuration:
-
+Add extension to your PHP configuration.
 
 FreeBSD
 -------

--- a/es/reference/install.rst
+++ b/es/reference/install.rst
@@ -47,7 +47,7 @@ Paquetes específicos para plataformas comunes:
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -69,21 +69,24 @@ Añadiendo la extensión a php.ini:
 
 .. code-block:: bash
 
-    # Suse: Add this line in your php.ini
+    # Suse: Add a file called phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    # CentOS/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
     extension=phalcon.so
 
-    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    # Ubuntu/Debian with apache2: Add a file called 30-phalcon.ini in /etc/php5/apache2/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    # Ubuntu/Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian with php5-cli: Add a file called 30-phalcon.ini in /etc/php5/cli/conf.d/ with this content:
     extension=phalcon.so
 
 Reiniciando el servidor web.
 
-If you are running Debian with php5-fpm, restart it:
+If you are running Ubuntu/Debian with php5-fpm, restart it:
 
 .. code-block:: bash
 

--- a/es/reference/install.rst
+++ b/es/reference/install.rst
@@ -3,15 +3,11 @@ Instalación
 Las extensiones de PHP requieren un método diferente de instalación a los frameworks o bibliotecas tradicionales.
 Puedes descargar tanto un paquete binario para tu sistema o compilarlo desde el código fuente.
 
-.. highlights::
-    Phalcon puede ser compilado como mínimo para la version 5.3.1 de PHP, pero debido a errores antiguos de PHP que causan fallos y fugas de memoria, recomendamos usar al menos 5.3.11.
-
-.. highlights::
-    Versiones inferiores a PHP 5.3.9 tienen fallos de seguridad y no son recomendadas para sitios en producción. `Más información <http://www.infoworld.com/d/security/php-539-fixes-hash-collision-dos-vulnerability-183947>`_
-
 Windows
 -------
 Para usar Phalcon en Windows debes descargar_ un DLL y ubicarlo en el directorio de extensiones. Edita el php.ini y agrega al final:
+
+.. code-block:: bash
 
     extension=php_phalcon.dll
 
@@ -25,44 +21,39 @@ El siguiente video explica como instalar Phalcon en Windows paso a paso, el mate
 
 Guías Relacionadas
 ^^^^^^^^^^^^^^^^^^
-
 .. toctree::
     :maxdepth: 1
 
     xampp
     wamp
 
-Linux/Solaris/Mac
------------------
-En un sistema Linux/Solaris/Mac puedes compilar e instalar la extensión fácilmente desde la fuente del repositorio:
+Linux/Solaris
+-------------
+En un sistema Linux/Solaris puedes compilar e instalar la extensión fácilmente desde la fuente del repositorio:
 
 Requerimientos
 ^^^^^^^^^^^^^^
 Los paquetes requeridos son:
 
-* PHP 5.3.x/5.4.x fuentes de desarrollo (development resources)
-* Compilador GCC (Linux/Solaris) o Xcode (Mac)
+* PHP >= 5.3 fuentes de desarrollo (development resources)
+* Compilador GCC (Linux/Solaris)
 * Git (a menos que descargues el paquete manualmente desde Github)
 
 Paquetes específicos para plataformas comunes:
 
 .. code-block:: bash
 
-    #Ubuntu
-    sudo apt-get install git-core gcc autoconf
-    sudo apt-get install php5-dev php5-mysql
+    # Ubuntu
+    sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
-    #Suse
-    sudo yast -i gcc make autoconf2.13
-    sudo yast -i php5-devel php5-mysql
+    # Suse
+    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
 
-    #CentOS/RedHat
-    sudo yum install gcc make
-    sudo yum install php-devel
+    # CentOS/RedHat/Fedora
+    sudo yum install php-devel pcre-devel gcc make
 
-    #Solaris
-    pkg install gcc-45
-    pkg install php-53 apache-php53
+    # Solaris
+    pkg install gcc-45 php-53 apache-php53
 
 Compilación
 ^^^^^^^^^^^
@@ -70,25 +61,77 @@ Compilando la extensión:
 
 .. code-block:: bash
 
-    git clone git://github.com/phalcon/cphalcon.git
+    git clone --depth=1 git://github.com/phalcon/cphalcon.git
     cd cphalcon/build
     sudo ./install
 
-Añadiendo la extensión a php.ini
+Añadiendo la extensión a php.ini:
 
 .. code-block:: bash
 
+    # Suse: Add this line in your php.ini
+    extension=phalcon.so
+
+    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
     extension=phalcon.so
 
 Reiniciando el servidor web.
+
+If you are running Debian with php5-fpm, restart it:
+
+.. code-block:: bash
+
+    sudo service php5-fpm restart
 
 Phalcon automáticamente detecta tu arquitectura de procesador, sin embargo, puedes forzar la compilación para la arquitectura deseada:
 
 .. code-block:: bash
 
+    cd cphalcon/build
     sudo ./install 32bits
     sudo ./install 64bits
     sudo ./install safe
+
+If the automatic installer fails try building the extension manually:
+
+.. code-block:: bash
+
+    cd cphalcon/build/64bits
+    export CFLAGS="-O2 --fvisibility=hidden"
+    ./configure --enable-phalcon
+    make && sudo make install
+
+Mac OS X
+--------
+On a Mac OS X system you can compile and install the extension from the source code:
+
+Requirements
+^^^^^^^^^^^^
+Prerequisite packages are:
+
+* PHP >= 5.4 development resources
+* XCode
+
+.. code-block:: bash
+
+    # brew
+    brew tap homebrew/homebrew-php
+    brew install php54-phalcon
+    brew install php55-phalcon
+    brew install php56-phalcon
+
+    # MacPorts
+    sudo port install php54-phalcon
+    sudo port install php55-phalcon
+    sudo port install php56-phalcon
+
+Add extension to your PHP configuration.
 
 FreeBSD
 -------
@@ -102,12 +145,11 @@ o
 
 .. code-block:: bash
 
-    export CFLAGS="-O2 -fno-delete-null-pointer-checks"
+    export CFLAGS="-O2 --fvisibility=hidden"
     cd /usr/ports/www/phalcon && make install clean
 
 Notas para la instalación
 -------------------------
-
 Notas para los servidores web:
 
 .. toctree::

--- a/fr/reference/install.rst
+++ b/fr/reference/install.rst
@@ -1,22 +1,13 @@
 Installation
 ============
-PHP extensions require a slightly different installation method to a traditional PHP-based library or framework. You can either
-download a binary package for the system of your choice or build it from the sources.
-
-During the last few months, we have extensively researched PHP's behavior, investigating areas for significant
-optimizations (big or small). Through understanding of the Zend Engine, we managed to remove unecessary validations,
-compacted code, performed optimizations and generated low-level solutions so as to achieve maximum performance
-from Phalcon.
-
-.. highlights::
-    Phalcon compiles from PHP 5.3.1, but because of old PHP bugs causing memory leaks, we highly recommend you use at least PHP 5.3.11 or greater.
-
-.. highlights::
-    PHP versions below 5.3.9 have several security flaws and these aren't recommended for production web sites. `Learn more <http://www.infoworld.com/d/security/php-539-fixes-hash-collision-dos-vulnerability-183947>`_
+PHP extensions require a slightly different installation method to a traditional PHP-based library or framework.
+You can either download a binary package for the system of your choice or build it from the sources.
 
 Windows
 -------
 To use phalcon on Windows you can download_ a DLL library. Edit your php.ini file and then append at the end:
+
+.. code-block:: bash
 
     extension=php_phalcon.dll
 
@@ -36,37 +27,33 @@ Related Guides
     xampp
     wamp
 
-Linux/Solaris/Mac
------------------
-On a Linux/Solaris/Mac system you can easily compile and install the extension from the source code:
+Linux/Solaris
+-------------
+On a Linux/Solaris system you can easily compile and install the extension from the source code:
 
 Requirements
 ^^^^^^^^^^^^
 Prerequisite packages are:
 
-* PHP 5.3.x/5.4.x/5.5.x development resources
-* GCC compiler (Linux/Solaris) or Xcode (Mac)
+* PHP >= 5.3 development resources
+* GCC compiler (Linux/Solaris)
 * Git (if not already installed in your system - unless you download the package from GitHub and upload it on your server via FTP/SFTP)
 
 Specific packages for common platforms:
 
 .. code-block:: bash
 
-    #Ubuntu
-    sudo apt-get install git-core gcc autoconf
-    sudo apt-get install php5-dev php5-mysql
+    # Ubuntu
+    sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
-    #Suse
-    sudo yast -i gcc make autoconf2.13
-    sudo yast -i php5-devel php5-mysql
+    # Suse
+    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
 
-    #CentOS/RedHat
-    sudo yum install gcc make
-    sudo yum install php-devel
+    # CentOS/RedHat/Fedora
+    sudo yum install php-devel pcre-devel gcc make
 
-    #Solaris
-    pkg install gcc-45
-    pkg install php-53 apache-php53
+    # Solaris
+    pkg install gcc-45 php-53 apache-php53
 
 Compilation
 ^^^^^^^^^^^
@@ -74,25 +61,77 @@ Creating the extension:
 
 .. code-block:: bash
 
-    git clone git://github.com/phalcon/cphalcon.git
+    git clone --depth=1 git://github.com/phalcon/cphalcon.git
     cd cphalcon/build
     sudo ./install
 
-Add extension to your php.ini
+Add extension to your PHP configuration:
 
 .. code-block:: bash
 
+    # Suse: Add this line in your php.ini
+    extension=phalcon.so
+
+    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
     extension=phalcon.so
 
 Restart the webserver.
+
+If you are running Debian with php5-fpm, restart it:
+
+.. code-block:: bash
+
+    sudo service php5-fpm restart
 
 Phalcon automatically detects your architecture, however, you can force the compilation for a specific architecture:
 
 .. code-block:: bash
 
+    cd cphalcon/build
     sudo ./install 32bits
     sudo ./install 64bits
     sudo ./install safe
+
+If the automatic installer fails try building the extension manually:
+
+.. code-block:: bash
+
+    cd cphalcon/build/64bits
+    export CFLAGS="-O2 --fvisibility=hidden"
+    ./configure --enable-phalcon
+    make && sudo make install
+
+Mac OS X
+--------
+On a Mac OS X system you can compile and install the extension from the source code:
+
+Requirements
+^^^^^^^^^^^^
+Prerequisite packages are:
+
+* PHP >= 5.4 development resources
+* XCode
+
+.. code-block:: bash
+
+    # brew
+    brew tap homebrew/homebrew-php
+    brew install php54-phalcon
+    brew install php55-phalcon
+    brew install php56-phalcon
+
+    # MacPorts
+    sudo port install php54-phalcon
+    sudo port install php55-phalcon
+    sudo port install php56-phalcon
+
+Add extension to your PHP configuration.
 
 FreeBSD
 -------
@@ -106,7 +145,7 @@ or
 
 .. code-block:: bash
 
-    export CFLAGS="-O2 -fno-delete-null-pointer-checks"
+    export CFLAGS="-O2 --fvisibility=hidden"
     cd /usr/ports/www/phalcon && make install clean
 
 Installation Notes

--- a/fr/reference/install.rst
+++ b/fr/reference/install.rst
@@ -47,7 +47,7 @@ Specific packages for common platforms:
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -69,21 +69,24 @@ Add extension to your PHP configuration:
 
 .. code-block:: bash
 
-    # Suse: Add this line in your php.ini
+    # Suse: Add a file called phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    # CentOS/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
     extension=phalcon.so
 
-    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    # Ubuntu/Debian with apache2: Add a file called 30-phalcon.ini in /etc/php5/apache2/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    # Ubuntu/Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian with php5-cli: Add a file called 30-phalcon.ini in /etc/php5/cli/conf.d/ with this content:
     extension=phalcon.so
 
 Restart the webserver.
 
-If you are running Debian with php5-fpm, restart it:
+If you are running Ubuntu/Debian with php5-fpm, restart it:
 
 .. code-block:: bash
 

--- a/ja/reference/install.rst
+++ b/ja/reference/install.rst
@@ -47,7 +47,7 @@ Linux/Solaris の環境では、簡単に拡張モジュールをソースコー
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -69,21 +69,24 @@ php.iniに拡張モジュールを追加します。
 
 .. code-block:: bash
 
-    # Suse: Add this line in your php.ini
+    # Suse: Add a file called phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    # CentOS/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
     extension=phalcon.so
 
-    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    # Ubuntu/Debian with apache2: Add a file called 30-phalcon.ini in /etc/php5/apache2/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    # Ubuntu/Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian with php5-cli: Add a file called 30-phalcon.ini in /etc/php5/cli/conf.d/ with this content:
     extension=phalcon.so
 
 最後にWEBサーバーを再起動します。
 
-If you are running Debian with php5-fpm, restart it:
+If you are running Ubuntu/Debian with php5-fpm, restart it:
 
 .. code-block:: bash
 

--- a/ja/reference/install.rst
+++ b/ja/reference/install.rst
@@ -1,18 +1,13 @@
 インストール
 ============
-
 PHP拡張モジュールは、従来のPHPベースのライブラリやフレームワークとは若干異なるインストール方法をとります。
 あなたのシステム向けのバイナリパッケージをダウンロードするか、ソースコードからビルドする２つの方法があります。
-
-.. highlights::
-    PhalconはPHP 5.3.1以降でコンパイルできますが、古いPHPはメモリリークを引き起こすバグがあるため、少なくとも PHP 5.3.11以降を使用することを推奨しています。
-
-.. highlights::
-   PHP 5.3.9 以前のものには、いくつかのセキュリティ的な欠陥があり、商用環境のWEBサイトでの使用は推奨しておりません。 `詳細はこちら <http://www.infoworld.com/d/security/php-539-fixes-hash-collision-dos-vulnerability-183947>`_
 
 Windows
 -------
 Windows上でPhalconを使用するには、DLLライブラリをダウンロードします。そして php.iniを編集し、最後に次の行を追加します。
+
+.. code-block:: bash
 
     extension=php_phalcon.dll
 
@@ -32,37 +27,33 @@ Windows上でPhalconを使用するには、DLLライブラリをダウンロー
     xampp
     wamp
 
-Linux/Solaris/Mac
------------------
-Linux/Solaris/Mac の環境では、簡単に拡張モジュールをソースコードからコンパイルしてインストールすることができます。
+Linux/Solaris
+-------------
+Linux/Solaris の環境では、簡単に拡張モジュールをソースコードからコンパイルしてインストールすることができます。
 
 必要条件
 ^^^^^^^^
 必要となるパッケージは次の通りです：
 
-* PHP 5.3.x/5.4.x/5.5.x development resources
-* GCC compiler (Linux/Solaris) or Xcode (Mac)
+* PHP >= 5.3 development resources
+* GCC compiler (Linux/Solaris)
 * Git (if not already installed in your system - unless you download the package from GitHub and upload it on your server via FTP/SFTP)
 
 一般的なプラットフォームにおける具体的なパッケージ:
 
 .. code-block:: bash
 
-    #Ubuntu
-    sudo apt-get install git-core gcc autoconf
-    sudo apt-get install php5-dev php5-mysql
+    # Ubuntu
+    sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
-    #Suse
-    sudo yast -i gcc make autoconf2.13
-    sudo yast -i php5-devel php5-pear php5-mysql
+    # Suse
+    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
 
-    #CentOS/RedHat
-    sudo yum install gcc make
-    sudo yum install php-devel
+    # CentOS/RedHat/Fedora
+    sudo yum install php-devel pcre-devel gcc make
 
-    #Solaris
-    pkg install gcc-45
-    pkg install php-53 apache-php53
+    # Solaris
+    pkg install gcc-45 php-53 apache-php53
 
 コンパイル
 ^^^^^^^^^^
@@ -70,7 +61,7 @@ Linux/Solaris/Mac の環境では、簡単に拡張モジュールをソース�
 
 .. code-block:: bash
 
-    git clone git://github.com/phalcon/cphalcon.git
+    git clone --depth=1 git://github.com/phalcon/cphalcon.git
     cd cphalcon/build
     sudo ./install
 
@@ -78,17 +69,69 @@ php.iniに拡張モジュールを追加します。
 
 .. code-block:: bash
 
+    # Suse: Add this line in your php.ini
+    extension=phalcon.so
+
+    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
     extension=phalcon.so
 
 最後にWEBサーバーを再起動します。
+
+If you are running Debian with php5-fpm, restart it:
+
+.. code-block:: bash
+
+    sudo service php5-fpm restart
 
 Phalconは自動的にシステムのアーキテクチャを判定しますが、指定したアーキテクチャ向けにコンパイルすることを強制することができます。
 
 .. code-block:: bash
 
+    cd cphalcon/build
     sudo ./install 32bits
     sudo ./install 64bits
     sudo ./install safe
+
+If the automatic installer fails try building the extension manually:
+
+.. code-block:: bash
+
+    cd cphalcon/build/64bits
+    export CFLAGS="-O2 --fvisibility=hidden"
+    ./configure --enable-phalcon
+    make && sudo make install
+
+Mac OS X
+--------
+On a Mac OS X system you can compile and install the extension from the source code:
+
+Requirements
+^^^^^^^^^^^^
+Prerequisite packages are:
+
+* PHP >= 5.4 development resources
+* XCode
+
+.. code-block:: bash
+
+    # brew
+    brew tap homebrew/homebrew-php
+    brew install php54-phalcon
+    brew install php55-phalcon
+    brew install php56-phalcon
+
+    # MacPorts
+    sudo port install php54-phalcon
+    sudo port install php55-phalcon
+    sudo port install php56-phalcon
+
+Add extension to your PHP configuration.
 
 FreeBSD
 -------
@@ -102,7 +145,7 @@ or
 
 .. code-block:: bash
 
-    export CFLAGS="-O2 -fno-delete-null-pointer-checks"
+    export CFLAGS="-O2 --fvisibility=hidden"
     cd /usr/ports/www/phalcon && make install clean
 
 インストール ノート

--- a/pl/reference/install.rst
+++ b/pl/reference/install.rst
@@ -29,30 +29,30 @@ Powiązane Przewodniki
 
 Linux/Solaris
 -------------
-Na systemach Linux/Solaris/Mac możesz w łatwy sposób skompilować i zainstalować rozszerzenie z kodu źródłowego:
+Na systemach Linux/Solaris możesz w łatwy sposób skompilować i zainstalować rozszerzenie z kodu źródłowego:
 
 Wymagania
 ^^^^^^^^^
 Wstępnie wymagane pakiety:
 
-* Pliki źródłowe PHP 5.3.x/5.4.x/5.5.x
-* Kompilator GCC (Linux/Solaris) lub Xcode (Mac)
+* Pliki źródłowe PHP >= 5.3
+* Kompilator GCC (Linux/Solaris)
 * Git (jeśli nie jest jeszcze zainstalowany na twoim systemie - chyba ze pobierzesz pakiet z GitHub i prześlesz go na swój serwer przez FTP/SFTP)
 
 Specyficzne pakiety dla wspólnych platform:
 
 .. code-block:: bash
 
-    #Ubuntu
+    # Ubuntu
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
-    #Suse
+    # Suse
     sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
 
-    #CentOS/RedHat/Fedora
+    # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
 
-    #Solaris
+    # Solaris
     pkg install gcc-45 php-53 apache-php53
 
 Kompilacja
@@ -69,16 +69,25 @@ Dodaj rozszerzenie do swojej konfiguracji PHP:
 
 .. code-block:: bash
 
-    #Suse: Dodaj ta linię do swojego pliku php.ini
+    # Suse: Dodaj ta linię do swojego pliku php.ini
     extension=phalcon.so
 
-    #Centos/RedHat/Fedora: Stwórz plik o nazwie phalcon.ini w /etc/php.d/ z następującą zawartością:
+    # Centos/RedHat/Fedora: Stwórz plik o nazwie phalcon.ini w /etc/php.d/ z następującą zawartością:
     extension=phalcon.so
 
-    #Ubuntu/Debian: Stwórz plik o nazwie 30-phalcon.ini w /etc/php.d/ z następującą zawartością:
+    # Ubuntu/Debian: Stwórz plik o nazwie 30-phalcon.ini w /etc/php.d/ z następującą zawartością:
+    extension=phalcon.so
+
+    # Debian z php5-fpm: Stwórz plik o nazwie 30-phalcon.ini w /etc/php5/fpm/conf.d/ z następującą zawartością:
     extension=phalcon.so
 
 Zrestartuj serwer.
+
+If you are running Debian with php5-fpm, restart it:
+
+.. code-block:: bash
+
+    sudo service php5-fpm restart
 
 Phalcon automatycznie wykrywa architekturę twojego systemu, możesz jednak wymusić kompilację dla konkretnej architektury:
 
@@ -106,23 +115,23 @@ Wymagania
 ^^^^^^^^^
 Wstępnie wymagane pakiety:
 
-* Pliki źródłowe PHP 5.3.x lub nowsze
+* Pliki źródłowe PHP >= 5.4
 * XCode
 
 .. code-block:: bash
 
-    #brew
-    sudo brew install php53-phalcon
-    sudo brew install php54-phalcon
-    sudo brew install php55-phalcon
+    # brew
+    brew tap homebrew/homebrew-php
+    brew install php54-phalcon
+    brew install php55-phalcon
+    brew install php56-phalcon
 
-    #MacPorts
-    sudo port install php53-phalcon
+    # MacPorts
     sudo port install php54-phalcon
     sudo port install php55-phalcon
+    sudo port install php56-phalcon
 
-Dodaj rozszerzenie do swojej konfiguracji PHP:
-
+Dodaj rozszerzenie do swojej konfiguracji PHP.
 
 FreeBSD
 -------

--- a/pl/reference/install.rst
+++ b/pl/reference/install.rst
@@ -47,7 +47,7 @@ Specyficzne pakiety dla wspólnych platform:
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -69,21 +69,24 @@ Dodaj rozszerzenie do swojej konfiguracji PHP:
 
 .. code-block:: bash
 
-    # Suse: Dodaj ta linię do swojego pliku php.ini
+    # Suse: Stwórz plik o nazwie phalcon.ini w /etc/php5/conf.d/ z następującą zawartością:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: Stwórz plik o nazwie phalcon.ini w /etc/php.d/ z następującą zawartością:
+    # CentOS/RedHat/Fedora: Stwórz plik o nazwie phalcon.ini w /etc/php.d/ z następującą zawartością:
     extension=phalcon.so
 
-    # Ubuntu/Debian: Stwórz plik o nazwie 30-phalcon.ini w /etc/php.d/ z następującą zawartością:
+    # Ubuntu/Debian z apache2: Stwórz plik o nazwie 30-phalcon.ini w /etc/php5/apache2/conf.d/ z następującą zawartością:
     extension=phalcon.so
 
-    # Debian z php5-fpm: Stwórz plik o nazwie 30-phalcon.ini w /etc/php5/fpm/conf.d/ z następującą zawartością:
+    # Ubuntu/Debian z php5-fpm: Stwórz plik o nazwie 30-phalcon.ini w /etc/php5/fpm/conf.d/ z następującą zawartością:
+    extension=phalcon.so
+
+    # Ubuntu/Debian z php5-cli: Stwórz plik o nazwie 30-phalcon.ini w /etc/php5/cli/conf.d/ z następującą zawartością:
     extension=phalcon.so
 
 Zrestartuj serwer.
 
-If you are running Debian with php5-fpm, restart it:
+If you are running Ubuntu/Debian with php5-fpm, restart it:
 
 .. code-block:: bash
 

--- a/pt/reference/install.rst
+++ b/pt/reference/install.rst
@@ -47,7 +47,7 @@ Pacotes específicos para plataformas em comum:
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -69,21 +69,24 @@ Adicione a extensão ao seu php.ini
 
 .. code-block:: bash
 
-    # Suse: Add this line in your php.ini
+    # Suse: Add a file called phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    # CentOS/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
     extension=phalcon.so
 
-    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    # Ubuntu/Debian with apache2: Add a file called 30-phalcon.ini in /etc/php5/apache2/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    # Ubuntu/Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian with php5-cli: Add a file called 30-phalcon.ini in /etc/php5/cli/conf.d/ with this content:
     extension=phalcon.so
 
 Reinicie o servidor web.
 
-If you are running Debian with php5-fpm, restart it:
+If you are running Ubuntu/Debian with php5-fpm, restart it:
 
 .. code-block:: bash
 

--- a/pt/reference/install.rst
+++ b/pt/reference/install.rst
@@ -1,16 +1,13 @@
 ﻿Instalação
 ==========
-A instalação de uma extensão PHP é levemente diferente dos métodos tradicionais de instalação das bibliotecas de um framework baseado em PHP. Você pode fazer o download dos pacotes binários construído para o seu sistema de sua escolha ou compilar-los a partir das fontes.
-
-.. highlights::
-    Phalcon é compilado do PHP 5.3.1, como as versões antigas do PHP causavam bugs relacionados à falha de memória, recomendamos fortemente utilizar pelo menos uma versão 5.3.11 ou maior.
-
-.. highlights::
-    Versões do PHP abaixo da 5.3.9 tem várias falhas de segurança e essas versões não são recomendadas para sites em produção. `Saiba Mais <http://www.infoworld.com/d/security/php-539-fixes-hash-collision-dos-vulnerability-183947>`_
+A instalação de uma extensão PHP é levemente diferente dos métodos tradicionais de instalação das bibliotecas de um framework baseado em PHP.
+Você pode fazer o download dos pacotes binários construído para o seu sistema de sua escolha ou compilar-los a partir das fontes.
 
 Windows
 -------
 Para utilizar o phalcon no Windows você pode fazer o download_ da biblioteca DLL. Editar o seu php.ini adicionando no final a seguinte instrução:
+
+.. code-block:: bash
 
     extension=php_phalcon.dll
 
@@ -30,37 +27,33 @@ Guias Relacionados
     xampp
     wamp
 
-Linux/Solaris/Mac
------------------
-Nos sistemas Linux/Solaris/Mac você pode facilmente compilar e instalar a extensão diretamente dos códigos fontes:
+Linux/Solaris
+-------------
+Nos sistemas Linux/Solaris você pode facilmente compilar e instalar a extensão diretamente dos códigos fontes:
 
 Requerimentos
 ^^^^^^^^^^^^^
 Os pacotes pré-requisitos são:
 
-* PHP 5.3.x/5.4.x/5.5.(recursos de desenvolvimento)
-* Compilador GCC (Linux/Solaris) ou Xcode (Mac)
+* PHP >= 5.3 recursos de desenvolvimento
+* Compilador GCC (Linux/Solaris)
 * Git (caso ainda não esteja instalado no seu sistema - a menos que você faça o download do pacote no GitHub e depois o upload para o seu servidor via FTP/SFTP)
 
 Pacotes específicos para plataformas em comum:
 
 .. code-block:: bash
 
-    #Ubuntu
-    sudo apt-get install git-core gcc autoconf
-    sudo apt-get install php5-dev php5-mysql
+    # Ubuntu
+    sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
-    #Suse
-    sudo yast -i gcc make autoconf2.13
-    sudo yast -i php5-devel php5-mysql
+    # Suse
+    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
 
-    #CentOS/RedHat
-    sudo yum install gcc make
-    sudo yum install php-devel
+    # CentOS/RedHat/Fedora
+    sudo yum install php-devel pcre-devel gcc make
 
-    #Solaris
-    pkg install gcc-45
-    pkg install php-53 apache-php53
+    # Solaris
+    pkg install gcc-45 php-53 apache-php53
 
 Compilação
 ^^^^^^^^^^
@@ -68,7 +61,7 @@ Criando a extensão:
 
 .. code-block:: bash
 
-    git clone git://github.com/phalcon/cphalcon.git
+    git clone --depth=1 git://github.com/phalcon/cphalcon.git
     cd cphalcon/build
     sudo ./install
 
@@ -76,17 +69,69 @@ Adicione a extensão ao seu php.ini
 
 .. code-block:: bash
 
+    # Suse: Add this line in your php.ini
+    extension=phalcon.so
+
+    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
     extension=phalcon.so
 
 Reinicie o servidor web.
+
+If you are running Debian with php5-fpm, restart it:
+
+.. code-block:: bash
+
+    sudo service php5-fpm restart
 
 Phalcon automaticamente detecta a sua arquitetura, no entanto, você poderá força a compilação para uma arquitetura especifica:
 
 .. code-block:: bash
 
+    cd cphalcon/build
     sudo ./install 32bits
     sudo ./install 64bits
     sudo ./install safe
+
+If the automatic installer fails try building the extension manually:
+
+.. code-block:: bash
+
+    cd cphalcon/build/64bits
+    export CFLAGS="-O2 --fvisibility=hidden"
+    ./configure --enable-phalcon
+    make && sudo make install
+
+Mac OS X
+--------
+On a Mac OS X system you can compile and install the extension from the source code:
+
+Requirements
+^^^^^^^^^^^^
+Prerequisite packages are:
+
+* PHP >= 5.4 development resources
+* XCode
+
+.. code-block:: bash
+
+    # brew
+    brew tap homebrew/homebrew-php
+    brew install php54-phalcon
+    brew install php55-phalcon
+    brew install php56-phalcon
+
+    # MacPorts
+    sudo port install php54-phalcon
+    sudo port install php55-phalcon
+    sudo port install php56-phalcon
+
+Add extension to your PHP configuration.
 
 FreeBSD
 -------
@@ -100,7 +145,7 @@ ou
 
 .. code-block:: bash
 
-    export CFLAGS="-O2 -fno-delete-null-pointer-checks"
+    export CFLAGS="-O2 --fvisibility=hidden"
     cd /usr/ports/www/phalcon && make install clean
 
 Notas de Instalação

--- a/ru/reference/install.rst
+++ b/ru/reference/install.rst
@@ -47,7 +47,7 @@ Linux/Solaris
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -69,21 +69,24 @@ Linux/Solaris
 
 .. code-block:: bash
 
-    # Suse: добавьте эту строку в php.ini
+    # Suse: создайте файл phalcon.ini в /etc/php5/conf.d/ со следующим содержимым:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: создайте файл phalcon.ini в /etc/php.d/ со следующим содержимым:
+    # CentOS/RedHat/Fedora: создайте файл phalcon.ini в /etc/php.d/ со следующим содержимым:
     extension=phalcon.so
 
-    # Ubuntu/Debian: создайте файл 30-phalcon.ini в /etc/php5/conf.d/ со следующим содержимым:
+    # Ubuntu/Debian с apache2: создайте файл 30-phalcon.ini в /etc/php5/apache2/conf.d/ со следующим содержимым:
     extension=phalcon.so
 
-    # Debian с php5-fpm: создайте файл 30-phalcon.ini в /etc/php5/fpm/conf.d/ со следующим содержимым:
+    # Ubuntu/Debian с php5-fpm: создайте файл 30-phalcon.ini в /etc/php5/fpm/conf.d/ со следующим содержимым:
+    extension=phalcon.so
+
+    # Ubuntu/Debian с php5-cli: создайте файл 30-phalcon.ini в /etc/php5/cli/conf.d/ со следующим содержимым:
     extension=phalcon.so
 
 Перезапустите веб-сервер.
 
-Если вы используете Debian с php5-fpm, то перезапустите и его:
+Если вы используете Ubuntu/Debian с php5-fpm, то перезапустите и его:
 
 .. code-block:: bash
 

--- a/ru/reference/install.rst
+++ b/ru/reference/install.rst
@@ -1,21 +1,17 @@
 Установка
 =========
-Расширения для PHP устанавливаются несколько иначе чем обычные библиотеки или PHP-фреймворки. Вы можете скачать готовый бинарный
-файл для своей системы, или собрать его из исходников самостоятельно.
-
-.. highlights::
-    Phalcon работает с PHP 5.3.1, но ошибки в старых версиях PHP вызывают утечки памяти, и для надёжной работы рекомендуем использовать как минимум PHP 5.3.11 или выше.
-
-.. highlights::
-    В PHP версиях ниже 5.3.9 есть ошибки, влияющие на безопасность, эти версии не рекомендуется использовать. `Подробнее <http://www.infoworld.com/d/security/php-539-fixes-hash-collision-dos-vulnerability-183947>`_
+Расширения для PHP устанавливаются несколько иначе, чем обычные библиотеки или PHP фреймворки.
+Вы можете скачать готовый бинарный файл для своей системы или собрать его из исходников самостоятельно.
 
 Windows
 -------
-Для использования Phalcon в среде Windows достаточно `скачать`_ DLL библиотеку и добавить в конце php.ini :
+Для использования Phalcon в Windows достаточно `скачать`_ DLL библиотеку и добавить в конце php.ini:
+
+.. code-block:: bash
 
     extension=php_phalcon.dll
 
-Перезапустить веб-сервер.
+Затем перезапустите ваш веб-сервер.
 
 Существует обучающий скринкаст с пошаговой установкой Phalcon на Windows:
 
@@ -26,42 +22,38 @@ Windows
 Краткое руководство
 ^^^^^^^^^^^^^^^^^^^
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   xampp
-   wamp
+    xampp
+    wamp
 
-Linux/Solaris/Mac
------------------
-Пользователи Linux/Solaris/Mac могут просто собрать Phalcon из исходных файлов:
+Linux/Solaris
+-------------
+Пользователи систем Linux/Solaris могут просто собрать Phalcon из исходных файлов:
 
 Требования
 ^^^^^^^^^^
 Необходимы пакеты:
 
-* Пакеты для разработки PHP 5.3.x/5.4.x/5.5.x
-* Компилятор GCC (Linux/Solaris) или Xcode (Mac)
-* Git (если он не установлен - пакет можно загрузить с GitHub и закачать на свой сервер по FTP/SFTP)
+* Пакеты для разработки PHP >= 5.3
+* Компилятор GCC (Linux/Solaris)
+* Git (если не установлен, иначе, архив можно скачать с GitHub и затем загрузить на свой сервер по FTP/SFTP)
 
-Специфичные пакеты для разных платформ:
+Пакеты, специфичные для различных платформ:
 
 .. code-block:: bash
 
-    #Ubuntu
-    sudo apt-get install git-core gcc autoconf
-    sudo apt-get install php5-dev php5-mysql
+    # Ubuntu
+    sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
-    #Suse
-    sudo yast -i gcc make autoconf2.13
-    sudo yast -i php5-devel php5-pear php5-mysql
+    # Suse
+    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
 
-    #CentOS/RedHat
-    sudo yum install gcc make
-    sudo yum install php-devel
+    # CentOS/RedHat/Fedora
+    sudo yum install php-devel pcre-devel gcc make
 
-    #Solaris
-    pkg install gcc-45
-    pkg install php-53 apache-php53
+    # Solaris
+    pkg install gcc-45 php-53 apache-php53
 
 Компиляция
 ^^^^^^^^^^
@@ -69,29 +61,81 @@ Linux/Solaris/Mac
 
 .. code-block:: bash
 
-    git clone git://github.com/phalcon/cphalcon.git
+    git clone --depth=1 git://github.com/phalcon/cphalcon.git
     cd cphalcon/build
     sudo ./install
 
-Добавьте его в php.ini
+Добавьте его в вашу PHP конфигурацию:
 
 .. code-block:: bash
 
+    # Suse: добавьте эту строку в php.ini
+    extension=phalcon.so
+
+    # Centos/RedHat/Fedora: создайте файл phalcon.ini в /etc/php.d/ со следующим содержимым:
+    extension=phalcon.so
+
+    # Ubuntu/Debian: создайте файл 30-phalcon.ini в /etc/php5/conf.d/ со следующим содержимым:
+    extension=phalcon.so
+
+    # Debian с php5-fpm: создайте файл 30-phalcon.ini в /etc/php5/fpm/conf.d/ со следующим содержимым:
     extension=phalcon.so
 
 Перезапустите веб-сервер.
+
+Если вы используете Debian с php5-fpm, то перезапустите и его:
+
+.. code-block:: bash
+
+    sudo service php5-fpm restart
 
 При компиляции Phalcon сам выявляет тип платформы, но можно указать и явно:
 
 .. code-block:: bash
 
+    cd cphalcon/build
     sudo ./install 32bits
     sudo ./install 64bits
     sudo ./install safe
 
+Если автоматическая установка завершается с ошибкой, то попробуйте собрать расширение вручную:
+
+.. code-block:: bash
+
+    cd cphalcon/build/64bits
+    export CFLAGS="-O2 --fvisibility=hidden"
+    ./configure --enable-phalcon
+    make && sudo make install
+
+Mac OS X
+--------
+В Mac OS X вы можете скомпилировать и установить расширение из исходников:
+
+Требования
+^^^^^^^^^^
+Необходимы пакеты:
+
+* Пакеты для разработки PHP >= 5.4
+* XCode
+
+.. code-block:: bash
+
+    # brew
+    brew tap homebrew/homebrew-php
+    brew install php54-phalcon
+    brew install php55-phalcon
+    brew install php56-phalcon
+
+    # MacPorts
+    sudo port install php54-phalcon
+    sudo port install php55-phalcon
+    sudo port install php56-phalcon
+
+Добавьте его в вашу PHP конфигурацию.
+
 FreeBSD
 -------
-Порт доступен для FreeBSD. Для установки служат простые команды:
+Порт доступен для FreeBSD. Для установки достаточно пары простых команд:
 
 .. code-block:: bash
 
@@ -101,7 +145,7 @@ FreeBSD
 
 .. code-block:: bash
 
-    export CFLAGS="-O2 -fno-delete-null-pointer-checks"
+    export CFLAGS="-O2 --fvisibility=hidden"
     cd /usr/ports/www/phalcon && make install clean
 
 Замечания по установке

--- a/zh/reference/install.rst
+++ b/zh/reference/install.rst
@@ -46,7 +46,7 @@ Linux/Solaris
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
-    sudo yast -i gcc make autoconf2.13 php5-devel php5-pear php5-mysql
+    sudo yast -i gcc make autoconf php5-devel php5-pear php5-mysql
 
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
@@ -68,21 +68,24 @@ Linux/Solaris
 
 .. code-block:: bash
 
-    # Suse: Add this line in your php.ini
+    # Suse: Add a file called phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Centos/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
+    # CentOS/RedHat/Fedora: Add a file called phalcon.ini in /etc/php.d/ with this content:
     extension=phalcon.so
 
-    # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
+    # Ubuntu/Debian with apache2: Add a file called 30-phalcon.ini in /etc/php5/apache2/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    # Ubuntu/Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
+    extension=phalcon.so
+
+    # Ubuntu/Debian with php5-cli: Add a file called 30-phalcon.ini in /etc/php5/cli/conf.d/ with this content:
     extension=phalcon.so
 
 重启Web服务器.
 
-如果你在 Debian 下使用 php5-fpm，重启命令为：
+如果你在 Ubuntu/Debian 下使用 php5-fpm，重启命令为：
 
 .. code-block:: bash
 

--- a/zh/reference/install.rst
+++ b/zh/reference/install.rst
@@ -2,15 +2,11 @@
 ====================
 作为PHP C拓展形式的Phalcon，需要一个略微不同于传统PHP的库或框架的安装方法。你可以选择一个当前系统的一个二进制包下载，或者使用源代码构建它。
 
-.. highlights::
-    Phalcon 可编译在PHP 5.3.1及以上版本，但是因为老PHP版本错误导致内存泄漏，我们强烈推荐你使用PHP 5.3.11或更高版本。
-
-.. highlights::
-    PHP 5.3.9版本以前有几个安全漏洞，不建议在生产网站中使用。`学习更多 <http://www.infoworld.com/d/security/php-539-fixes-hash-collision-dos-vulnerability-183947>`_
-
 Windows
 -------
 要在Windows上使用Phalcon，你可以下载一个DLL库。编辑php.ini文件，并且在最后附加上：
+
+.. code-block:: bash
 
     extension=php_phalcon.dll
 
@@ -30,23 +26,23 @@ Windows
     xampp
     wamp
 
-Linux/Solaris/Mac
------------------
-在Linux/Solaris/Mac系统下，你能很轻易从源代码编译和安装这个拓展:
+Linux/Solaris
+-------------
+在Linux/Solaris系统下，你能很轻易从源代码编译和安装这个拓展:
 
 基本要求（Requirements）
 ^^^^^^^^^^^^^^^^^^^^^^^^
 必要的包:
 
-* PHP 5.3.x/5.4.x/5.5.x development resources
-* GCC compiler (Linux/Solaris) or Xcode (Mac)
+* PHP >= 5.3 development resources
+* GCC compiler (Linux/Solaris)
 * Git (如果不是已经安装在你的系统，且你没有从Github上下载这个包并通过FTP/SFTP上传到你的服务器上)
 
 通用平台下安装指定的软件包：
 
 .. code-block:: bash
 
-    #Ubuntu
+    # Ubuntu
     sudo apt-get install php5-dev libpcre3-dev gcc make php5-mysql
 
     # Suse
@@ -55,7 +51,7 @@ Linux/Solaris/Mac
     # CentOS/RedHat/Fedora
     sudo yum install php-devel pcre-devel gcc make
 
-    #Solaris
+    # Solaris
     pkg install gcc-45 php-53 apache-php53
 
 编译（Compilation）
@@ -81,7 +77,7 @@ Linux/Solaris/Mac
     # Ubuntu/Debian: Add a file called 30-phalcon.ini in /etc/php5/conf.d/ with this content:
     extension=phalcon.so
 
-    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/30-phalcon.ini with this content:
+    # Debian with php5-fpm: Add a file called 30-phalcon.ini in /etc/php5/fpm/conf.d/ with this content:
     extension=phalcon.so
 
 重启Web服务器.
@@ -134,8 +130,7 @@ Prerequisite packages are:
     sudo port install php55-phalcon
     sudo port install php56-phalcon
 
-Add extension to your PHP configuration:
-
+Add extension to your PHP configuration.
 
 FreeBSD
 -------


### PR DESCRIPTION
Linux/Solaris:
```rst
Prerequisite packages are:

* PHP >= 5.3 development resources
* GCC compiler (Linux/Solaris)
* Git (if not already installed in your system - unless you download the package from GitHub and upload it on your server via FTP/SFTP)
```
Mac OS X:
```rst
Prerequisite packages are:

* PHP >= 5.4 development resources
* XCode
```
Why for Linux from 5.3, but for Mac OS from 5.4?
