### PR TITLE
Avoids pitfalls & common mistakes for nginx config

### DIFF
--- a/en/reference/nginx.rst
+++ b/en/reference/nginx.rst
@@ -24,11 +24,7 @@ Using :code:`$_GET['_url']` as source of URIs:
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
-        }
+        try_files $uri $uri/ /index.php?_url=$uri&$args;
 
         location ~ \.php {
             fastcgi_pass unix:/run/php-fpm/php-fpm.sock;
@@ -40,10 +36,6 @@ Using :code:`$_GET['_url']` as source of URIs:
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -77,10 +69,6 @@ Using :code:`$_SERVER['REQUEST_URI']` as source of URIs:
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -96,22 +84,13 @@ Dedicated Instance
 
         charset      utf-8;
 
+        root   /srv/www/htdocs/phalcon-website/public;
+
         #access_log  /var/log/nginx/host.access.log  main;
 
         location / {
-            root   /srv/www/htdocs/phalcon-website/public;
             index  index.php index.html index.htm;
-
-            # if file exists return it right away
-            if (-f $request_filename) {
-                break;
-            }
-
-            # otherwise rewrite it
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
+            try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -127,9 +106,6 @@ Dedicated Instance
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
-        }
     }
 
 Configuration by Host
@@ -150,11 +126,7 @@ And this second configuration allow you to have different configurations by host
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
-        }
+        try_files $uri $uri/ /index.php?_url=$uri&$args;
 
         location ~ \.php {
             # try_files    $uri =404;
@@ -167,10 +139,6 @@ And this second configuration allow you to have different configurations by host
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/en/reference/nginx.rst
+++ b/en/reference/nginx.rst
@@ -109,6 +109,9 @@ Dedicated Instance
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
+        location ~ /\.ht {
+            deny all;
+        }
     }
 
 Configuration by Host

--- a/en/reference/nginx.rst
+++ b/en/reference/nginx.rst
@@ -24,7 +24,9 @@ Using :code:`$_GET['_url']` as source of URIs:
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ /index.php?_url=$uri&$args;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
+        }
 
         location ~ \.php {
             fastcgi_pass unix:/run/php-fpm/php-fpm.sock;
@@ -88,9 +90,10 @@ Dedicated Instance
 
         #access_log  /var/log/nginx/host.access.log  main;
 
+        index  index.php index.html index.htm;
+
         location / {
-            index  index.php index.html index.htm;
-            try_files $uri $uri/ /index.php?_url=$uri&$args;
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -126,7 +129,9 @@ And this second configuration allow you to have different configurations by host
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ /index.php?_url=$uri&$args;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
+        }
 
         location ~ \.php {
             # try_files    $uri =404;

--- a/es/reference/nginx.rst
+++ b/es/reference/nginx.rst
@@ -24,10 +24,8 @@ Using :code:`$_GET['_url']` as source of URIs:
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -40,10 +38,6 @@ Using :code:`$_GET['_url']` as source of URIs:
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -77,10 +71,6 @@ Using :code:`$_SERVER['REQUEST_URI']` as source of URIs:
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -90,47 +80,39 @@ Instancias dedicadas
 ^^^^^^^^^^^^^^^^^^^^
 .. code-block:: nginx
 
-    server {
-        listen       80;
-        server_name  localhost;
+server {
+    listen      80;
 
-        charset      utf-8;
+    server_name localhost;
 
-        #access_log  /var/log/nginx/host.access.log  main;
+    root        /var/www/$host/public;
 
-        location / {
-            root   /srv/www/htdocs/phalcon-website/public;
-            index  index.php index.html index.htm;
+    access_log  /var/log/nginx/$host-access.log;
+    error_log   /var/log/nginx/$host-error.log error;
 
-            # if file exists return it right away
-            if (-f $request_filename) {
-                break;
-            }
+    index index.php index.html index.htm;
 
-            # otherwise rewrite it
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
-        }
-
-        location ~ \.php {
-            # try_files    $uri =404;
-
-            fastcgi_index  /index.php;
-            fastcgi_pass   127.0.0.1:9000;
-
-            include fastcgi_params;
-            fastcgi_split_path_info       ^(.+\.php)(/.+)$;
-            fastcgi_param PATH_INFO       $fastcgi_path_info;
-            fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
-            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
-        }
+    location / {
+      try_files $uri $uri/ /index.php?_url=$uri&$args;
     }
+
+    location ~ \.php {
+        # try_files    $uri =404;
+
+        fastcgi_index  /index.php;
+        fastcgi_pass   127.0.0.1:9000;
+
+        include fastcgi_params;
+        fastcgi_split_path_info       ^(.+\.php)(/.+)$;
+        fastcgi_param PATH_INFO       $fastcgi_path_info;
+        fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
 
 Configuración por Host
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -150,10 +132,8 @@ Esta configuración te permite tener varias configuraciones por Host:
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -167,10 +147,6 @@ Esta configuración te permite tener varias configuraciones por Host:
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/fr/reference/nginx.rst
+++ b/fr/reference/nginx.rst
@@ -24,10 +24,8 @@ Using :code:`$_GET['_url']` as source of URIs:
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -40,10 +38,6 @@ Using :code:`$_GET['_url']` as source of URIs:
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -77,10 +71,6 @@ Using :code:`$_SERVER['REQUEST_URI']` as source of URIs:
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -96,22 +86,14 @@ Dedicated Instance
 
         charset      utf-8;
 
+        root   /srv/www/htdocs/phalcon-website/public;
+
         #access_log  /var/log/nginx/host.access.log  main;
 
+        index  index.php index.html index.htm;
+
         location / {
-            root   /srv/www/htdocs/phalcon-website/public;
-            index  index.php index.html index.htm;
-
-            # if file exists return it right away
-            if (-f $request_filename) {
-                break;
-            }
-
-            # otherwise rewrite it
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -127,8 +109,8 @@ Dedicated Instance
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
+        location ~ /\.ht {
+            deny all;
         }
     }
 
@@ -150,10 +132,8 @@ And this second configuration allow you to have different configurations by host
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -167,10 +147,6 @@ And this second configuration allow you to have different configurations by host
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/ja/reference/nginx.rst
+++ b/ja/reference/nginx.rst
@@ -28,10 +28,8 @@ PhalconのためのNginxの設定
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -44,10 +42,6 @@ PhalconのためのNginxの設定
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -81,10 +75,6 @@ PhalconのためのNginxの設定
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -100,22 +90,14 @@ PhalconのためのNginxの設定
 
         charset      utf-8;
 
+        root   /srv/www/htdocs/phalcon-website/public;
+
         #access_log  /var/log/nginx/host.access.log  main;
 
+        index  index.php index.html index.htm;
+
         location / {
-            root   /srv/www/htdocs/phalcon-website/public;
-            index  index.php index.html index.htm;
-
-            # if file exists return it right away
-            if (-f $request_filename) {
-                break;
-            }
-
-            # otherwise rewrite it
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -131,8 +113,8 @@ PhalconのためのNginxの設定
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
+        location ~ /\.ht {
+            deny all;
         }
     }
 
@@ -154,10 +136,8 @@ PhalconのためのNginxの設定
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -171,10 +151,6 @@ PhalconのためのNginxの設定
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/pl/reference/nginx.rst
+++ b/pl/reference/nginx.rst
@@ -24,10 +24,8 @@ Using :code:`$_GET['_url']` as source of URIs:
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -40,10 +38,6 @@ Using :code:`$_GET['_url']` as source of URIs:
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -77,10 +71,6 @@ Using :code:`$_SERVER['REQUEST_URI']` as source of URIs:
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -96,22 +86,14 @@ Dedicated Instance
 
         charset      utf-8;
 
+        root   /srv/www/htdocs/phalcon-website/public;
+
         #access_log  /var/log/nginx/host.access.log  main;
 
+        index  index.php index.html index.htm;
+
         location / {
-            root   /srv/www/htdocs/phalcon-website/public;
-            index  index.php index.html index.htm;
-
-            # if file exists return it right away
-            if (-f $request_filename) {
-                break;
-            }
-
-            # otherwise rewrite it
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -127,8 +109,8 @@ Dedicated Instance
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
+        location ~ /\.ht {
+            deny all;
         }
     }
 
@@ -150,10 +132,8 @@ And this second configuration allow you to have different configurations by host
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -167,10 +147,6 @@ And this second configuration allow you to have different configurations by host
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/pt/reference/nginx.rst
+++ b/pt/reference/nginx.rst
@@ -24,10 +24,8 @@ Utilizando :code:`$_GET['_url']` como fonte das URIs:
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -40,10 +38,6 @@ Utilizando :code:`$_GET['_url']` como fonte das URIs:
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -77,10 +71,6 @@ Utilizando :code:`$_SERVER['REQUEST_URI']` como fonte das URIs:
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -96,22 +86,14 @@ Instância Dedicada
 
         charset      utf-8;
 
+        root   /srv/www/htdocs/phalcon-website/public;
+
         #access_log  /var/log/nginx/host.access.log  main;
 
+        index  index.php index.html index.htm;
+
         location / {
-            root   /srv/www/htdocs/phalcon-website/public;
-            index  index.php index.html index.htm;
-
-            # if file exists return it right away
-            if (-f $request_filename) {
-                break;
-            }
-
-            # otherwise rewrite it
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -127,8 +109,8 @@ Instância Dedicada
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
+        location ~ /\.ht {
+            deny all;
         }
     }
 
@@ -150,10 +132,8 @@ Esta segunda configuração permite você ter diferentes configurações por hos
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -167,10 +147,6 @@ Esta segunda configuração permite você ter diferentes configurações por hos
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/ru/reference/nginx.rst
+++ b/ru/reference/nginx.rst
@@ -24,10 +24,8 @@ Nginx_ - это свободный, с открытым исходным код�
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -40,10 +38,6 @@ Nginx_ - это свободный, с открытым исходным код�
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -77,10 +71,6 @@ Nginx_ - это свободный, с открытым исходным код�
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -96,22 +86,14 @@ Nginx_ - это свободный, с открытым исходным код�
 
         charset      utf-8;
 
+        root   /srv/www/htdocs/phalcon-website/public;
+
         #access_log  /var/log/nginx/host.access.log  main;
 
+        index  index.php index.html index.htm;
+
         location / {
-            root   /srv/www/htdocs/phalcon-website/public;
-            index  index.php index.html index.htm;
-
-            # если запрашиваемый файл существует, то возвращаем его
-            if (-f $request_filename) {
-                break;
-            }
-
-            # иначе изменяем строку запроса
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -127,8 +109,8 @@ Nginx_ - это свободный, с открытым исходным код�
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
+        location ~ /\.ht {
+            deny all;
         }
     }
 
@@ -150,10 +132,8 @@ Nginx_ - это свободный, с открытым исходным код�
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -167,10 +147,6 @@ Nginx_ - это свободный, с открытым исходным код�
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {

--- a/zh/reference/nginx.rst
+++ b/zh/reference/nginx.rst
@@ -24,10 +24,8 @@ Using :code:`$_GET['_url']` as source of URIs:
 
         root /var/www/phalcon/public;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -40,10 +38,6 @@ Using :code:`$_GET['_url']` as source of URIs:
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
         }
 
         location ~ /\.ht {
@@ -77,10 +71,6 @@ Using :code:`$_SERVER['REQUEST_URI']` as source of URIs:
                 include fastcgi_params;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/phalcon/public;
-        }
-
         location ~ /\.ht {
             deny all;
         }
@@ -96,22 +86,14 @@ Using :code:`$_SERVER['REQUEST_URI']` as source of URIs:
 
         charset      utf-8;
 
+        root   /srv/www/htdocs/phalcon-website/public;
+
         #access_log  /var/log/nginx/host.access.log  main;
 
+        index  index.php index.html index.htm;
+
         location / {
-            root   /srv/www/htdocs/phalcon-website/public;
-            index  index.php index.html index.htm;
-
-            # if file exists return it right away
-            if (-f $request_filename) {
-                break;
-            }
-
-            # otherwise rewrite it
-            if (!-e $request_filename) {
-                rewrite ^(.+)$ /index.php?_url=$1 last;
-                break;
-            }
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -127,8 +109,8 @@ Using :code:`$_SERVER['REQUEST_URI']` as source of URIs:
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         }
 
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /srv/www/htdocs/phalcon-website/public;
+        location ~ /\.ht {
+            deny all;
         }
     }
 
@@ -150,10 +132,8 @@ And this second configuration allow you to have different configurations by host
 
         index index.php index.html index.htm;
 
-        try_files $uri $uri/ @rewrite;
-
-        location @rewrite {
-            rewrite ^(.*)$ /index.php?_url=$1;
+        location / {
+          try_files $uri $uri/ /index.php?_url=$uri&$args;
         }
 
         location ~ \.php {
@@ -167,10 +147,6 @@ And this second configuration allow you to have different configurations by host
             fastcgi_param PATH_INFO       $fastcgi_path_info;
             fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        }
-
-        location ~* ^/(css|img|js|flv|swf|download)/(.+)$ {
-            root /var/www/$host/public;
         }
 
         location ~ /\.ht {


### PR DESCRIPTION
* Removes *root* instructions inside *location* blocks
* Replaces all *if* statements with 301 redirects or *try_files* instructions
* Replaces all *rewrite* statements with *try_files* instructions

Reference: https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/