### PR TITLE
Updated links to blog.phalconphp.com posts

### DIFF
--- a/en/reference/annotations.rst
+++ b/en/reference/annotations.rst
@@ -389,4 +389,4 @@ annotations adapters or extend the existing ones.
 
 External Resources
 ------------------
-* `Tutorial: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Tutorial: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/en/reference/samples.rst
+++ b/en/reference/samples.rst
@@ -9,14 +9,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Phalcon's website
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, Layouts and more
                     </a>
                 </div>
@@ -28,14 +28,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         PHP Alternative website: Multi-Lingual, Complex Routing and more
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213">
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: Phalcon's forum
                     </a>
                 </div>
@@ -47,14 +47,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: Large Data, Volt, PHQL and Caching and more
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: Security, Authentication, Authorization and more
                     </a>
                 </div>

--- a/en/reference/tools.rst
+++ b/en/reference/tools.rst
@@ -354,7 +354,7 @@ Conclusion
 ----------
 Phalcon Developer Tools provides an easy way to generate code for your application, reducing development time and potential coding errors.
 
-.. _blog post: http://blog.phalconphp.com/post/23251010409
+.. _blog post: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/

--- a/es/reference/annotations.rst
+++ b/es/reference/annotations.rst
@@ -389,4 +389,4 @@ annotations adapters or extend the existing ones.
 
 External Resources
 ------------------
-* `Tutorial: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Tutorial: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/es/reference/samples.rst
+++ b/es/reference/samples.rst
@@ -9,14 +9,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Phalcon's website
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, Layouts and more
                     </a>
                 </div>
@@ -28,14 +28,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         PHP Alternative website: Multi-Lingual, Complex Routing and more
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213>
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: Phalcon's forum
                     </a>
                 </div>
@@ -47,14 +47,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: Large Data, Volt, PHQL and Caching and more
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: Security, Authentication, Authorization and more
                     </a>
                 </div>

--- a/es/reference/tools.rst
+++ b/es/reference/tools.rst
@@ -354,7 +354,7 @@ Conclusion
 ----------
 Phalcon Developer Tools provides an easy way to generate code for your application, reducing development time and potential coding errors.
 
-.. _blog post: http://blog.phalconphp.com/post/23251010409
+.. _blog post: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/

--- a/fr/reference/annotations.rst
+++ b/fr/reference/annotations.rst
@@ -389,4 +389,4 @@ annotations adapters or extend the existing ones.
 
 External Resources
 ------------------
-* `Tutorial: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Tutorial: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/fr/reference/samples.rst
+++ b/fr/reference/samples.rst
@@ -9,14 +9,14 @@ Les exemples suivants sont des applications complètes que vous pouvez utiliser 
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Site web de Phalcon
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, mise en page et plus encore
                     </a>
                 </div>
@@ -28,14 +28,14 @@ Les exemples suivants sont des applications complètes que vous pouvez utiliser 
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         PHP Site Web alternatif: Multilingue, Routage complexe et plus encore
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213">
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: Le forum de Phalcon
                     </a>
                 </div>
@@ -47,14 +47,14 @@ Les exemples suivants sont des applications complètes que vous pouvez utiliser 
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: De nombreuses données, Volt, PHQL et un système de cache.
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: Securité, Authentication, Authorisation et plus encore
                     </a>
                 </div>

--- a/fr/reference/tools.rst
+++ b/fr/reference/tools.rst
@@ -356,7 +356,7 @@ Conclusion
 Les outils pour développeurs Phalcon fournissent un moyen simple de générer du code pour votre application.
 Cela réduit le temps de développement et diminue le nombre potentiel d'erreur de code.
 
-.. _blog post: http://blog.phalconphp.com/post/23251010409
+.. _blog post: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/

--- a/ja/reference/annotations.rst
+++ b/ja/reference/annotations.rst
@@ -381,4 +381,4 @@ You can use annotations to tell the ACL which controllers belong to the administ
 
 外部資料
 ------------------
-* `Tutorial: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Tutorial: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/ja/reference/samples.rst
+++ b/ja/reference/samples.rst
@@ -9,14 +9,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Phalcon's website
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, Layouts and more
                     </a>
                 </div>
@@ -28,14 +28,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         PHP Alternative website: Multi-Lingual, Complex Routing and more
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213">
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: Phalcon's forum
                     </a>
                 </div>
@@ -47,14 +47,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: Large Data, Volt, PHQL and Caching and more
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: Security, Authentication, Authorization and more
                     </a>
                 </div>

--- a/ja/reference/tools.rst
+++ b/ja/reference/tools.rst
@@ -354,7 +354,7 @@ The screencast below shows how to integrate developer tools with the `PhpStorm I
 ----------
 Phalcon Developer Tools provides an easy way to generate code for your application, reducing development time and potential coding errors.
 
-.. _blog post: http://blog.phalconphp.com/post/23251010409
+.. _blog post: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/

--- a/pl/reference/annotations.rst
+++ b/pl/reference/annotations.rst
@@ -389,4 +389,4 @@ annotations adapters or extend the existing ones.
 
 External Resources
 ------------------
-* `Tutorial: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Tutorial: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/pl/reference/samples.rst
+++ b/pl/reference/samples.rst
@@ -9,14 +9,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Phalcon's website
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, Layouts and more
                     </a>
                 </div>
@@ -28,14 +28,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         PHP Alternative website: Multi-Lingual, Complex Routing and more
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213">
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: Phalcon's forum
                     </a>
                 </div>
@@ -47,14 +47,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: Large Data, Volt, PHQL and Caching and more
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: Security, Authentication, Authorization and more
                     </a>
                 </div>

--- a/pl/reference/tools.rst
+++ b/pl/reference/tools.rst
@@ -354,7 +354,7 @@ Conclusion
 ----------
 Phalcon Developer Tools provides an easy way to generate code for your application, reducing development time and potential coding errors.
 
-.. _blog post: http://blog.phalconphp.com/post/23251010409
+.. _blog post: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/

--- a/pt/reference/annotations.rst
+++ b/pt/reference/annotations.rst
@@ -389,4 +389,4 @@ annotations adapters or extend the existing ones.
 
 External Resources
 ------------------
-* `Tutorial: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Tutorial: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/pt/reference/samples.rst
+++ b/pt/reference/samples.rst
@@ -9,14 +9,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Phalcon's website
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, Layouts and more
                     </a>
                 </div>
@@ -28,14 +28,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         PHP Alternative website: Multi-Lingual, Complex Routing and more
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213">
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: Phalcon's forum
                     </a>
                 </div>
@@ -47,14 +47,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: Large Data, Volt, PHQL and Caching and more
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: Security, Authentication, Authorization and more
                     </a>
                 </div>

--- a/pt/reference/tools.rst
+++ b/pt/reference/tools.rst
@@ -354,7 +354,7 @@ Conclusion
 ----------
 Phalcon Developer Tools provides an easy way to generate code for your application, reducing development time and potential coding errors.
 
-.. _blog post: http://blog.phalconphp.com/post/23251010409
+.. _blog post: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/

--- a/ru/reference/annotations.rst
+++ b/ru/reference/annotations.rst
@@ -388,4 +388,4 @@ You can use annotations to tell the ACL which controllers belong to the administ
 
 Внешние источники
 -----------------
-* `Обучение: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Обучение: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/ru/reference/samples.rst
+++ b/ru/reference/samples.rst
@@ -9,14 +9,14 @@
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Сайт Phalcon
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, шаблоны и многое другое
                     </a>
                 </div>
@@ -28,14 +28,14 @@
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         Альтернативный сайт PHP: многоязычность, сложная маршрутизация и многое другое
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213">
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: форум Phalcon
                     </a>
                 </div>
@@ -47,14 +47,14 @@
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: большое количество данных, Volt, PHQL, кэширование и многое другое
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: безопасность, аутентификация, авторизация и многое другое
                     </a>
                 </div>

--- a/ru/reference/tools.rst
+++ b/ru/reference/tools.rst
@@ -353,7 +353,7 @@ Scaffolding - это быстрый способ для получения ос�
 ----------
 Phalcon Developer Tools позволяет легко генерировать код для вашего приложения, сокращая время разработки и потенциальные ошибки.
 
-.. _блогозапись: http://blog.phalconphp.com/post/23251010409
+.. _блогозапись: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/

--- a/zh/reference/annotations.rst
+++ b/zh/reference/annotations.rst
@@ -382,4 +382,4 @@ You can use annotations to tell the ACL which controllers belong to the administ
 
 外部资源（External Resources）
 ------------------------------
-* `Tutorial: Creating a custom model's initializer with Annotations <http://blog.phalconphp.com/post/47471246411>`_
+* `Tutorial: Creating a custom model's initializer with Annotations <https://blog.phalconphp.com/post/tutorial-creating-a-custom-models-initializer>`_

--- a/zh/reference/samples.rst
+++ b/zh/reference/samples.rst
@@ -9,14 +9,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-1 sample">
                 <div>
-                    <a href="http://github.com/phalcon/website">
+                    <a href="https://github.com/phalcon/website">
                         Phalcon's website
                     </a>
                 </div>
             </td>
             <td class="sample-2 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/20928554661">
+                    <a href="https://blog.phalconphp.com/post/invo-a-sample-application">
                         INVO: CRUD, Acl, Layouts and more
                     </a>
                 </div>
@@ -28,14 +28,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-3 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/24622423072">
+                    <a href="https://blog.phalconphp.com/post/sample-application-php-alternative-site">
                         PHP Alternative website: Multi-Lingual, Complex Routing and more
                     </a>
                 </div>
             </td>
             <td class="sample-4 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/41461000213">
+                    <a href="https://blog.phalconphp.com/post/phosphorum-the-phalcon-forum">
                         Phosphorum: Phalcon's forum
                     </a>
                 </div>
@@ -47,14 +47,14 @@ Following examples are full applications you can use to learn more about Phalcon
         <tr>
             <td class="sample-5 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/37515965262">
+                    <a href="https://blog.phalconphp.com/post/sample-application-album-orama">
                         Album O'Rama: Large Data, Volt, PHQL and Caching and more
                     </a>
                 </div>
             </td>
             <td class="sample-6 sample">
                 <div>
-                    <a href="http://blog.phalconphp.com/post/49450016172">
+                    <a href="https://blog.phalconphp.com/post/sample-application-vokuro">
                         Vökuró: Security, Authentication, Authorization and more
                     </a>
                 </div>

--- a/zh/reference/tools.rst
+++ b/zh/reference/tools.rst
@@ -344,7 +344,7 @@ scaffold生成器会在相关的文件夹中生成若干个文档。 下面是�
 --------------------
 Phalcon开发辅助工具为我们提供了一种简易的产生应用代码的方法， 这可以减少开发时间及潜在的错误。
 
-.. _blog post: http://blog.phalconphp.com/post/23251010409
+.. _blog post: https://blog.phalconphp.com/post/dont-like-command-line-and-consoles-no-problem
 .. _Github: https://github.com/phalcon/phalcon-devtools
 .. _Bootstrap: http://twitter.github.com/bootstrap/
 .. _PhpStorm IDE: http://www.jetbrains.com/phpstorm/


### PR DESCRIPTION
Updated links to blog.phalconphp.com posts (annotation.rst, samples.rst, tools.rst); added missing quotation mark (es/reference/samples.rst)