### PR TITLE
Removed unknown type

### DIFF
--- a/scripts/gen-api.php
+++ b/scripts/gen-api.php
@@ -554,7 +554,7 @@ foreach ($classes as $className) {
                 } else if ($parameter->isArray()) {
                     $parameterType = 'array';
                 } else {
-                    $parameterType = 'unknown';
+                    $parameterType = 'mixed';
                 }
                 if (strpos($parameterType, 'Phalcon') !== false) {
                     if (class_exists($parameterType) || interface_exists($parameterType)) {


### PR DESCRIPTION
@SidRoberts I propose don't use `unknown` type

```php
public static tagHtmlClose (mixed $tagName, [mixed $useEol])
```
better than

```php
public static tagHtmlClose (unknown $tagName, [unknown $useEol])
```