### PR TITLE
Avoid underscores

### DIFF
--- a/en/reference/models.rst
+++ b/en/reference/models.rst
@@ -177,7 +177,7 @@ If you use underscores in your property names, you must still use camel case in 
 with magic methods. (e.g. $model->getPropertyName instead of $model->getProperty_name, $model->findByPropertyName
 instead of $model->findByProperty_name, etc.). As much of the system expects camel case, and underscores are commonly
 removed, it is recommended to name your properties in the manner shown throughout the documentation. You can use a
-column map (as described above) to ensure proper mapping of your properties their database counterparts.
+column map (as described above) to ensure proper mapping of your properties to their database counterparts.
 
 Models in Namespaces
 ^^^^^^^^^^^^^^^^^^^^

--- a/en/reference/models.rst
+++ b/en/reference/models.rst
@@ -169,6 +169,16 @@ Public properties provide less complexity in development. However getters/setter
 extensibility and maintainability of applications. Developers can decide which strategy is more appropriate for the
 application they are creating. The ORM is compatible with both schemes of defining properties.
 
+.. highlights::
+
+    Underscores in property names can be problematic when using getters and setters.
+
+If you use underscores in your property names, you must still use camel case in your getter/setter declarations for use
+with magic methods. (e.g. $model->getPropertyName instead of $model->getProperty_name, $model->findByPropertyName
+instead of $model->findByProperty_name, etc.). As much of the system expects camel case, and underscores are commonly
+removed, it is recommended to name your properties in the manner shown throughout the documentation. You can use a
+column map (as described above) to ensure proper mapping of your properties their database counterparts.
+
 Models in Namespaces
 ^^^^^^^^^^^^^^^^^^^^
 Namespaces can be used to avoid class name collision. The mapped table is taken from the class name, in this case 'Robots':


### PR DESCRIPTION
While learning phalcon, I stumbled across this info and figured it would be a useful addition to the documentation (and maybe save other newcomers some time ... especially if they are in the habit of keeping their property names matched against their schema names).