### PR TITLE
Updated queue documentation to reflect YAML requirement.

### DIFF
--- a/en/reference/queue.rst
+++ b/en/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 Putting Jobs into the Queue
 ---------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message

--- a/es/reference/queue.rst
+++ b/es/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 Putting Jobs into the Queue
 ---------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message

--- a/fr/reference/queue.rst
+++ b/fr/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 Putting Jobs into the Queue
 ---------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message

--- a/id/reference/queue.rst
+++ b/id/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 Putting Jobs into the Queue
 ---------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message

--- a/ja/reference/queue.rst
+++ b/ja/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 ジョブをキューに入れる
 ---------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message

--- a/pl/reference/queue.rst
+++ b/pl/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 Putting Jobs into the Queue
 ---------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message

--- a/pt/reference/queue.rst
+++ b/pt/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 Putting Jobs into the Queue
 ---------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message

--- a/ru/reference/queue.rst
+++ b/ru/reference/queue.rst
@@ -13,6 +13,12 @@
 была вдохновлена Memcache_. Этот клиент прост, легок, и полностью специализируется на работе
 очереди.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 Добавление заданий в очередь
 ----------------------------
 После подключения к Beanstalk, вы можете добавлять столько заданий сколько необходимо. Разработчик

--- a/uk/reference/queue.rst
+++ b/uk/reference/queue.rst
@@ -16,6 +16,12 @@ Putting Jobs into the Queue
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message
 structure according to the needs of the application:
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 .. code-block:: php
 
     <?php

--- a/zh/reference/queue.rst
+++ b/zh/reference/queue.rst
@@ -11,6 +11,12 @@ While you can find more sophisticated PHP extensions to address queueing in your
 Phalcon provides a client for Beanstalk_, a job queueing backend inspired by Memcache_.
 It’s simple, lightweight, and completely specialized for job queueing.
 
+.. attention::
+
+    Some of the returns from queue methods require that the module Yaml be installed.  Please
+    refer to http://php.net/manual/book.yaml.php for more information.  For PHP < 7, Yaml 1.3.0
+    is acceptable.  For PHP >= 7, you will need to use Yaml >= 2.0.0.
+
 将任务加入队列（Putting Jobs into the Queue）
 ---------------------------------------------
 After connecting to Beanstalk you can insert as many jobs as required. You can define the message


### PR DESCRIPTION
I noticed that (at least) \Phalcon\Queue\Beanstalk->stats had a call to `yaml_parse()` which threw an exception when Yaml wasn't installed.  There was no indication that this was a requirement within the docs.  