### PR TITLE
Update 'string' filter type description

### DIFF
--- a/en/reference/filter.rst
+++ b/en/reference/filter.rst
@@ -18,7 +18,7 @@ The following are the built-in filters provided by this component:
 +-----------+---------------------------------------------------------------------------+
 | Name      | Description                                                               |
 +===========+===========================================================================+
-| string    | Strip tags and escapes HTML entities, including single and double quotes. |
+| string    | Strip tags and encode HTML entities, including single and double quotes. |
 +-----------+---------------------------------------------------------------------------+
 | email     | Remove all characters except letters, digits and !#$%&*+-/=?^_`{\|}~@.[]. |
 +-----------+---------------------------------------------------------------------------+


### PR DESCRIPTION
It took long time to get why quotes in request not escaped but encoded to html entity. So I have to check it in filter.zep:
> case Filter::FILTER_STRING:
> return filter_var(value, FILTER_SANITIZE_STRING);

But in description from http://php.net/manual/en/filter.filters.sanitize.php written:
"Strip tags, optionally strip or encode special characters." - so encoded and not escaped.