### PR TITLE
Add other languages examples of context parameters for Logging

### DIFF
--- a/es/reference/logging.rst
+++ b/es/reference/logging.rst
@@ -82,6 +82,14 @@ The example below shows how to create a log and add messages to it:
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 The log generated is below:
 
 .. code-block:: none
@@ -96,6 +104,7 @@ The log generated is below:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/fa/reference/logging.rst
+++ b/fa/reference/logging.rst
@@ -82,6 +82,14 @@ The example below shows how to create a log and add messages to it:
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 The log generated is below:
 
 .. code-block:: none
@@ -96,6 +104,7 @@ The log generated is below:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/fr/reference/logging.rst
+++ b/fr/reference/logging.rst
@@ -82,6 +82,14 @@ The example below shows how to create a log and add messages to it:
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 The log generated is below:
 
 .. code-block:: none
@@ -96,6 +104,7 @@ The log generated is below:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/id/reference/logging.rst
+++ b/id/reference/logging.rst
@@ -81,6 +81,14 @@ Contoh berikut menunjukkan bagaimana menciptakan sebuah log dan menambah pesan k
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 Log yang dihasilkan seperti berikut:
 
 .. code-block:: none
@@ -95,6 +103,7 @@ Log yang dihasilkan seperti berikut:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 Anda dapat mengatur level log menggunakan metode :code:`setLogLevel()`. Metode ini membutuhkan Logger constant dan hanya akan menyimpan pesan log yang sama atau lebih penting dari nilai konstan:
 

--- a/ja/reference/logging.rst
+++ b/ja/reference/logging.rst
@@ -82,6 +82,14 @@ The example below shows how to create a log and add messages to it:
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 The log generated is below:
 
 .. code-block:: none
@@ -96,6 +104,7 @@ The log generated is below:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/pl/reference/logging.rst
+++ b/pl/reference/logging.rst
@@ -82,6 +82,14 @@ The example below shows how to create a log and add messages to it:
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 The log generated is below:
 
 .. code-block:: none
@@ -96,6 +104,7 @@ The log generated is below:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/pt/reference/logging.rst
+++ b/pt/reference/logging.rst
@@ -82,6 +82,14 @@ The example below shows how to create a log and add messages to it:
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 The log generated is below:
 
 .. code-block:: none
@@ -96,6 +104,7 @@ The log generated is below:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/ru/reference/logging.rst
+++ b/ru/reference/logging.rst
@@ -84,6 +84,14 @@
         "Это сообщение"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 Результат кода:
 
 .. code-block:: none
@@ -98,6 +106,7 @@
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] Это тоже про ошибку
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] Это сообщение
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/uk/reference/logging.rst
+++ b/uk/reference/logging.rst
@@ -82,6 +82,14 @@ The example below shows how to create a log and add messages to it:
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 The log generated is below:
 
 .. code-block:: none
@@ -96,6 +104,7 @@ The log generated is below:
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 

--- a/zh/reference/logging.rst
+++ b/zh/reference/logging.rst
@@ -83,6 +83,14 @@ Phalcon提供了一个日志记录组件即 :doc:`Phalcon\\Logger <../api/Phalco
         "This is a message"
     );
 
+    // You can also pass context parameters like this
+    $logger->log(
+        "This is a {message}", 
+        [ 
+            'message' => 'parameter' 
+        ]
+    );
+
 产生的日志信息如下：
 
 .. code-block:: none
@@ -97,6 +105,7 @@ Phalcon提供了一个日志记录组件即 :doc:`Phalcon\\Logger <../api/Phalco
     [Tue, 28 Jul 15 22:09:02 -0500][ALERT] This is an alert message
     [Tue, 28 Jul 15 22:09:02 -0500][ERROR] This is another error message
     [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a message
+    [Tue, 28 Jul 15 22:09:02 -0500][DEBUG] This is a parameter
 
 You can also set a log level using the :code:`setLogLevel()` method. This method takes a Logger constant and will only save log messages that are as important or more important than the constant:
 


### PR DESCRIPTION
I've added an example for English docs and now I've added it to other languages