### PR TITLE
Update package versions in unit test docs.

### DIFF
--- a/en/reference/unit-testing.rst
+++ b/en/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/es/reference/unit-testing.rst
+++ b/es/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/fa/reference/unit-testing.rst
+++ b/fa/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/fr/reference/unit-testing.rst
+++ b/fr/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/id/reference/unit-testing.rst
+++ b/id/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/ja/reference/unit-testing.rst
+++ b/ja/reference/unit-testing.rst
@@ -9,7 +9,7 @@ PHPUnitをまだインストールしていないなら、以下のcomposerコ�
 
 .. code-block:: bash
 
-  composer require phpunit/phpunit
+  composer require phpunit/phpunit:^5.0
 
 
 あるいは、composer.json に以下の記述を追加します:
@@ -18,7 +18,7 @@ PHPUnitをまだインストールしていないなら、以下のcomposerコ�
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -93,7 +93,7 @@ incubatorライブラリを使うには以下のcomposerコマンドで追加し
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/pl/reference/unit-testing.rst
+++ b/pl/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/pt/reference/unit-testing.rst
+++ b/pt/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/ru/reference/unit-testing.rst
+++ b/ru/reference/unit-testing.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 или вручную добавить его в composer.json:
@@ -18,7 +18,7 @@
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/uk/reference/unit-testing.rst
+++ b/uk/reference/unit-testing.rst
@@ -9,7 +9,7 @@ If you don't already have phpunit installed, you can do it by using the followin
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 or by manually adding it to composer.json:
@@ -18,7 +18,7 @@ or by manually adding it to composer.json:
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ or by manually adding it to composer.json:
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 

--- a/zh/reference/unit-testing.rst
+++ b/zh/reference/unit-testing.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: bash
 
-    composer require phpunit/phpunit
+    composer require phpunit/phpunit:^5.0
 
 
 或者手动添加 composer.json：
@@ -18,7 +18,7 @@
 
     {
         "require-dev": {
-            "phpunit/phpunit": "~4.5"
+            "phpunit/phpunit": "^5.0"
         }
     }
 
@@ -94,7 +94,7 @@ PHPunit 辅助文件（The PHPunit helper file）
 
     {
         "require": {
-            "phalcon/incubator": "dev-master"
+            "phalcon/incubator": "^3.0"
         }
     }
 


### PR DESCRIPTION
Using the current documentation will pull in PHPunit 6, which basically breaks everything, both in phalcon and upstream. Until those issues are resolved, users should stick to a version 5 release.
