### PR TITLE
Fix tutorial invo English

### DIFF
--- a/en/reference/tutorial-invo.rst
+++ b/en/reference/tutorial-invo.rst
@@ -1,12 +1,13 @@
 Tutorial 2: Introducing INVO
 ============================
 
-In this second tutorial, we'll explain a more complete application in order to deepen the development with Phalcon.
-INVO is one of the applications we have created as samples. INVO is a small website that allows their users to
-generate invoices, and do other tasks such as manage their customers and products. You can clone its code from Github_.
+In this second tutorial, we'll explain a more complete application in order to gain a deeper understanding of
+developing with Phalcon. INVO is one of the sample applications we have created. INVO is a small website that
+allows users to generate invoices and do other tasks such as manage customers and products. You can clone its
+code from Github_.
 
-Also, INVO was made with `Bootstrap`_ as client-side framework. Although the application does not generate
-invoices, it still serves as an example to understand how the framework works.
+INVO was made with the client-side framework `Bootstrap`_. Although the application does not generate actual
+invoices, it still serves as an example showing how the framework works.
 
 Project Structure
 -----------------
@@ -34,29 +35,29 @@ Once you clone the project in your document root you'll see the following struct
         schemas/
 
 As you know, Phalcon does not impose a particular file structure for application development. This project
-provides a simple MVC structure and a public document root.
+has a simple MVC structure and a public document root.
 
 Once you open the application in your browser http://localhost/invo you'll see something like this:
 
 .. figure:: ../_static/img/invo-1.png
    :align: center
 
-The application is divided into two parts, a frontend, that is a public part where visitors can receive information
-about INVO and request contact information. The second part is the backend, an administrative area where a
-registered user can manage his/her products and customers.
+The application is divided into two parts: a frontend and a backend. The frontend is a public area where
+visitors can receive information about INVO and request contact information. The backend is an
+administrative area where registered users can manage their products and customers.
 
 Routing
 -------
 INVO uses the standard route that is built-in with the :doc:`Router <routing>` component. These routes match the following
 pattern: /:controller/:action/:params. This means that the first part of a URI is the controller, the second the
-action and the rest are the parameters.
+controller action and the rest are the parameters.
 
 The following route `/session/register` executes the controller SessionController and its action registerAction.
 
 Configuration
 -------------
 INVO has a configuration file that sets general parameters in the application. This file is located at
-app/config/config.ini and it's loaded in the very first lines of the application bootstrap (public/index.php):
+app/config/config.ini and is loaded in the very first lines of the application bootstrap (public/index.php):
 
 .. code-block:: php
 
@@ -72,8 +73,8 @@ app/config/config.ini and it's loaded in the very first lines of the application
     );
 
 :doc:`Phalcon\\Config <config>` allows us to manipulate the file in an object-oriented way.
-In this example, we're using a ini file as configuration, however, there are more adapters supported
-for configuration files. The configuration file contains the following settings:
+In this example, we're using an ini file for configuration but Phalcon has :doc:`adapters <config>` for other file types
+as well. The configuration file contains the following settings:
 
 .. code-block:: ini
 
@@ -92,8 +93,8 @@ for configuration files. The configuration file contains the following settings:
     libraryDir     = app/library/
     baseUri        = /invo/
 
-Phalcon hasn't any pre-defined convention settings. Sections help us to organize the options as appropriate.
-In this file there are two sections to be used later "application" and "database".
+Phalcon doesn't have any pre-defined settings convention. Sections help us to organize the options as appropriate.
+In this file there are two sections to be used later: "application" and "database".
 
 Autoloaders
 -----------
@@ -109,7 +110,7 @@ The second part that appears in the bootstrap file (public/index.php) is the aut
     require APP_PATH . "app/config/loader.php";
 
 The autoloader registers a set of directories in which the application will look for
-the classes that it eventually will need.
+the classes that it will eventually need.
 
 .. code-block:: php
 
@@ -131,9 +132,9 @@ the classes that it eventually will need.
     $loader->register();
 
 Note that the above code has registered the directories that were defined in the configuration file. The only
-directory that is not registered is the viewsDir, because it contains HTML + PHP files but no classes.
-Also, note that we have using a constant called APP_PATH, this constant is defined in the bootstrap
-(public/index.php) to allow us have a reference to the root of our project:
+directory that is not registered is the viewsDir because it contains HTML + PHP files but no classes.
+Also, note that we use a constant called APP_PATH. This constant is defined in the bootstrap
+(public/index.php) to allow us to have a reference to the root of our project:
 
 .. code-block:: php
 
@@ -148,8 +149,8 @@ Also, note that we have using a constant called APP_PATH, this constant is defin
 
 Registering services
 --------------------
-Another file that is required in the bootstrap is (app/config/services.php). This file allow
-us to organize the services that INVO does use.
+Another file that is required in the bootstrap is (app/config/services.php). This file allows
+us to organize the services that INVO uses.
 
 .. code-block:: php
 
@@ -160,7 +161,7 @@ us to organize the services that INVO does use.
      */
     require APP_PATH . "app/config/services.php";
 
-Service registration is achieved as in the previous tutorial, making use of a closure to lazily loads
+Service registration is achieved as in the previous tutorial, making use of closures to lazily load
 the required components:
 
 .. code-block:: php
@@ -210,10 +211,10 @@ which initializes and executes all that is necessary to make the application run
 
 Dependency Injection
 --------------------
-Look at the first line of the code block above, the Application class constructor is receiving the variable
-:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework,
+In the first line of the code block above, the Application class constructor is receiving the variable
+:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework
 so we need a component that acts as glue to make everything work together. That component is :doc:`Phalcon\\Di <../api/Phalcon_Di>`.
-It is a service container that also performs dependency injection and service location,
+It's a service container that also performs dependency injection and service location,
 instantiating all components as they are needed by the application.
 
 There are many ways of registering services in the container. In INVO, most services have been registered using
@@ -267,7 +268,7 @@ It registers the majority of services with components provided by the framework 
 the definition of some service we could just set it again as we did above with "session" or "url".
 This is the reason for the existence of the variable :code:`$di`.
 
-In next chapter, we will see how to authentication and authorization is implemented in INVO.
+In next chapter, we will see how authentication and authorization is implemented in INVO.
 
 .. _Github: https://github.com/phalcon/invo
 .. _Bootstrap: http://getbootstrap.com/

--- a/fa/reference/tutorial-invo.rst
+++ b/fa/reference/tutorial-invo.rst
@@ -1,12 +1,13 @@
 Tutorial 2: Introducing INVO
 ============================
 
-In this second tutorial, we'll explain a more complete application in order to deepen the development with Phalcon.
-INVO is one of the applications we have created as samples. INVO is a small website that allows their users to
-generate invoices, and do other tasks such as manage their customers and products. You can clone its code from Github_.
+In this second tutorial, we'll explain a more complete application in order to gain a deeper understanding of
+developing with Phalcon. INVO is one of the sample applications we have created. INVO is a small website that
+allows users to generate invoices and do other tasks such as manage customers and products. You can clone its
+code from Github_.
 
-Also, INVO was made with `Bootstrap`_ as client-side framework. Although the application does not generate
-invoices, it still serves as an example to understand how the framework works.
+INVO was made with the client-side framework `Bootstrap`_. Although the application does not generate actual
+invoices, it still serves as an example showing how the framework works.
 
 Project Structure
 -----------------
@@ -34,29 +35,29 @@ Once you clone the project in your document root you'll see the following struct
         schemas/
 
 As you know, Phalcon does not impose a particular file structure for application development. This project
-provides a simple MVC structure and a public document root.
+has a simple MVC structure and a public document root.
 
 Once you open the application in your browser http://localhost/invo you'll see something like this:
 
 .. figure:: ../_static/img/invo-1.png
    :align: center
 
-The application is divided into two parts, a frontend, that is a public part where visitors can receive information
-about INVO and request contact information. The second part is the backend, an administrative area where a
-registered user can manage his/her products and customers.
+The application is divided into two parts: a frontend and a backend. The frontend is a public area where
+visitors can receive information about INVO and request contact information. The backend is an
+administrative area where registered users can manage their products and customers.
 
 Routing
 -------
 INVO uses the standard route that is built-in with the :doc:`Router <routing>` component. These routes match the following
 pattern: /:controller/:action/:params. This means that the first part of a URI is the controller, the second the
-action and the rest are the parameters.
+controller action and the rest are the parameters.
 
 The following route `/session/register` executes the controller SessionController and its action registerAction.
 
 Configuration
 -------------
 INVO has a configuration file that sets general parameters in the application. This file is located at
-app/config/config.ini and it's loaded in the very first lines of the application bootstrap (public/index.php):
+app/config/config.ini and is loaded in the very first lines of the application bootstrap (public/index.php):
 
 .. code-block:: php
 
@@ -72,8 +73,8 @@ app/config/config.ini and it's loaded in the very first lines of the application
     );
 
 :doc:`Phalcon\\Config <config>` allows us to manipulate the file in an object-oriented way.
-In this example, we're using a ini file as configuration, however, there are more adapters supported
-for configuration files. The configuration file contains the following settings:
+In this example, we're using an ini file for configuration but Phalcon has :doc:`adapters <config>` for other file types
+as well. The configuration file contains the following settings:
 
 .. code-block:: ini
 
@@ -92,8 +93,8 @@ for configuration files. The configuration file contains the following settings:
     libraryDir     = app/library/
     baseUri        = /invo/
 
-Phalcon hasn't any pre-defined convention settings. Sections help us to organize the options as appropriate.
-In this file there are two sections to be used later "application" and "database".
+Phalcon doesn't have any pre-defined settings convention. Sections help us to organize the options as appropriate.
+In this file there are two sections to be used later: "application" and "database".
 
 Autoloaders
 -----------
@@ -109,7 +110,7 @@ The second part that appears in the bootstrap file (public/index.php) is the aut
     require APP_PATH . "app/config/loader.php";
 
 The autoloader registers a set of directories in which the application will look for
-the classes that it eventually will need.
+the classes that it will eventually need.
 
 .. code-block:: php
 
@@ -131,9 +132,9 @@ the classes that it eventually will need.
     $loader->register();
 
 Note that the above code has registered the directories that were defined in the configuration file. The only
-directory that is not registered is the viewsDir, because it contains HTML + PHP files but no classes.
-Also, note that we have using a constant called APP_PATH, this constant is defined in the bootstrap
-(public/index.php) to allow us have a reference to the root of our project:
+directory that is not registered is the viewsDir because it contains HTML + PHP files but no classes.
+Also, note that we use a constant called APP_PATH. This constant is defined in the bootstrap
+(public/index.php) to allow us to have a reference to the root of our project:
 
 .. code-block:: php
 
@@ -148,8 +149,8 @@ Also, note that we have using a constant called APP_PATH, this constant is defin
 
 Registering services
 --------------------
-Another file that is required in the bootstrap is (app/config/services.php). This file allow
-us to organize the services that INVO does use.
+Another file that is required in the bootstrap is (app/config/services.php). This file allows
+us to organize the services that INVO uses.
 
 .. code-block:: php
 
@@ -160,7 +161,7 @@ us to organize the services that INVO does use.
      */
     require APP_PATH . "app/config/services.php";
 
-Service registration is achieved as in the previous tutorial, making use of a closure to lazily loads
+Service registration is achieved as in the previous tutorial, making use of closures to lazily load
 the required components:
 
 .. code-block:: php
@@ -210,10 +211,10 @@ which initializes and executes all that is necessary to make the application run
 
 Dependency Injection
 --------------------
-Look at the first line of the code block above, the Application class constructor is receiving the variable
-:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework,
+In the first line of the code block above, the Application class constructor is receiving the variable
+:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework
 so we need a component that acts as glue to make everything work together. That component is :doc:`Phalcon\\Di <../api/Phalcon_Di>`.
-It is a service container that also performs dependency injection and service location,
+It's a service container that also performs dependency injection and service location,
 instantiating all components as they are needed by the application.
 
 There are many ways of registering services in the container. In INVO, most services have been registered using
@@ -267,7 +268,7 @@ It registers the majority of services with components provided by the framework 
 the definition of some service we could just set it again as we did above with "session" or "url".
 This is the reason for the existence of the variable :code:`$di`.
 
-In next chapter, we will see how to authentication and authorization is implemented in INVO.
+In next chapter, we will see how authentication and authorization is implemented in INVO.
 
 .. _Github: https://github.com/phalcon/invo
 .. _Bootstrap: http://getbootstrap.com/

--- a/id/reference/tutorial-invo.rst
+++ b/id/reference/tutorial-invo.rst
@@ -1,12 +1,13 @@
 Tutorial 2: Introducing INVO
 ============================
 
-In this second tutorial, we'll explain a more complete application in order to deepen the development with Phalcon.
-INVO is one of the applications we have created as samples. INVO is a small website that allows their users to
-generate invoices, and do other tasks such as manage their customers and products. You can clone its code from Github_.
+In this second tutorial, we'll explain a more complete application in order to gain a deeper understanding of
+developing with Phalcon. INVO is one of the sample applications we have created. INVO is a small website that
+allows users to generate invoices and do other tasks such as manage customers and products. You can clone its
+code from Github_.
 
-Also, INVO was made with `Bootstrap`_ as client-side framework. Although the application does not generate
-invoices, it still serves as an example to understand how the framework works.
+INVO was made with the client-side framework `Bootstrap`_. Although the application does not generate actual
+invoices, it still serves as an example showing how the framework works.
 
 Project Structure
 -----------------
@@ -34,29 +35,29 @@ Once you clone the project in your document root you'll see the following struct
         schemas/
 
 As you know, Phalcon does not impose a particular file structure for application development. This project
-provides a simple MVC structure and a public document root.
+has a simple MVC structure and a public document root.
 
 Once you open the application in your browser http://localhost/invo you'll see something like this:
 
 .. figure:: ../_static/img/invo-1.png
    :align: center
 
-The application is divided into two parts, a frontend, that is a public part where visitors can receive information
-about INVO and request contact information. The second part is the backend, an administrative area where a
-registered user can manage his/her products and customers.
+The application is divided into two parts: a frontend and a backend. The frontend is a public area where
+visitors can receive information about INVO and request contact information. The backend is an
+administrative area where registered users can manage their products and customers.
 
 Routing
 -------
 INVO uses the standard route that is built-in with the :doc:`Router <routing>` component. These routes match the following
 pattern: /:controller/:action/:params. This means that the first part of a URI is the controller, the second the
-action and the rest are the parameters.
+controller action and the rest are the parameters.
 
 The following route `/session/register` executes the controller SessionController and its action registerAction.
 
 Configuration
 -------------
 INVO has a configuration file that sets general parameters in the application. This file is located at
-app/config/config.ini and it's loaded in the very first lines of the application bootstrap (public/index.php):
+app/config/config.ini and is loaded in the very first lines of the application bootstrap (public/index.php):
 
 .. code-block:: php
 
@@ -72,8 +73,8 @@ app/config/config.ini and it's loaded in the very first lines of the application
     );
 
 :doc:`Phalcon\\Config <config>` allows us to manipulate the file in an object-oriented way.
-In this example, we're using a ini file as configuration, however, there are more adapters supported
-for configuration files. The configuration file contains the following settings:
+In this example, we're using an ini file for configuration but Phalcon has :doc:`adapters <config>` for other file types
+as well. The configuration file contains the following settings:
 
 .. code-block:: ini
 
@@ -92,8 +93,8 @@ for configuration files. The configuration file contains the following settings:
     libraryDir     = app/library/
     baseUri        = /invo/
 
-Phalcon hasn't any pre-defined convention settings. Sections help us to organize the options as appropriate.
-In this file there are two sections to be used later "application" and "database".
+Phalcon doesn't have any pre-defined settings convention. Sections help us to organize the options as appropriate.
+In this file there are two sections to be used later: "application" and "database".
 
 Autoloaders
 -----------
@@ -109,7 +110,7 @@ The second part that appears in the bootstrap file (public/index.php) is the aut
     require APP_PATH . "app/config/loader.php";
 
 The autoloader registers a set of directories in which the application will look for
-the classes that it eventually will need.
+the classes that it will eventually need.
 
 .. code-block:: php
 
@@ -131,9 +132,9 @@ the classes that it eventually will need.
     $loader->register();
 
 Note that the above code has registered the directories that were defined in the configuration file. The only
-directory that is not registered is the viewsDir, because it contains HTML + PHP files but no classes.
-Also, note that we have using a constant called APP_PATH, this constant is defined in the bootstrap
-(public/index.php) to allow us have a reference to the root of our project:
+directory that is not registered is the viewsDir because it contains HTML + PHP files but no classes.
+Also, note that we use a constant called APP_PATH. This constant is defined in the bootstrap
+(public/index.php) to allow us to have a reference to the root of our project:
 
 .. code-block:: php
 
@@ -148,8 +149,8 @@ Also, note that we have using a constant called APP_PATH, this constant is defin
 
 Registering services
 --------------------
-Another file that is required in the bootstrap is (app/config/services.php). This file allow
-us to organize the services that INVO does use.
+Another file that is required in the bootstrap is (app/config/services.php). This file allows
+us to organize the services that INVO uses.
 
 .. code-block:: php
 
@@ -160,7 +161,7 @@ us to organize the services that INVO does use.
      */
     require APP_PATH . "app/config/services.php";
 
-Service registration is achieved as in the previous tutorial, making use of a closure to lazily loads
+Service registration is achieved as in the previous tutorial, making use of closures to lazily load
 the required components:
 
 .. code-block:: php
@@ -210,10 +211,10 @@ which initializes and executes all that is necessary to make the application run
 
 Dependency Injection
 --------------------
-Look at the first line of the code block above, the Application class constructor is receiving the variable
-:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework,
+In the first line of the code block above, the Application class constructor is receiving the variable
+:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework
 so we need a component that acts as glue to make everything work together. That component is :doc:`Phalcon\\Di <../api/Phalcon_Di>`.
-It is a service container that also performs dependency injection and service location,
+It's a service container that also performs dependency injection and service location,
 instantiating all components as they are needed by the application.
 
 There are many ways of registering services in the container. In INVO, most services have been registered using
@@ -267,7 +268,7 @@ It registers the majority of services with components provided by the framework 
 the definition of some service we could just set it again as we did above with "session" or "url".
 This is the reason for the existence of the variable :code:`$di`.
 
-In next chapter, we will see how to authentication and authorization is implemented in INVO.
+In next chapter, we will see how authentication and authorization is implemented in INVO.
 
 .. _Github: https://github.com/phalcon/invo
 .. _Bootstrap: http://getbootstrap.com/

--- a/pl/reference/tutorial-invo.rst
+++ b/pl/reference/tutorial-invo.rst
@@ -1,12 +1,13 @@
 Tutorial 2: Introducing INVO
 ============================
 
-In this second tutorial, we'll explain a more complete application in order to deepen the development with Phalcon.
-INVO is one of the applications we have created as samples. INVO is a small website that allows their users to
-generate invoices, and do other tasks such as manage their customers and products. You can clone its code from Github_.
+In this second tutorial, we'll explain a more complete application in order to gain a deeper understanding of
+developing with Phalcon. INVO is one of the sample applications we have created. INVO is a small website that
+allows users to generate invoices and do other tasks such as manage customers and products. You can clone its
+code from Github_.
 
-Also, INVO was made with `Bootstrap`_ as client-side framework. Although the application does not generate
-invoices, it still serves as an example to understand how the framework works.
+INVO was made with the client-side framework `Bootstrap`_. Although the application does not generate actual
+invoices, it still serves as an example showing how the framework works.
 
 Project Structure
 -----------------
@@ -34,29 +35,29 @@ Once you clone the project in your document root you'll see the following struct
         schemas/
 
 As you know, Phalcon does not impose a particular file structure for application development. This project
-provides a simple MVC structure and a public document root.
+has a simple MVC structure and a public document root.
 
 Once you open the application in your browser http://localhost/invo you'll see something like this:
 
 .. figure:: ../_static/img/invo-1.png
    :align: center
 
-The application is divided into two parts, a frontend, that is a public part where visitors can receive information
-about INVO and request contact information. The second part is the backend, an administrative area where a
-registered user can manage his/her products and customers.
+The application is divided into two parts: a frontend and a backend. The frontend is a public area where
+visitors can receive information about INVO and request contact information. The backend is an
+administrative area where registered users can manage their products and customers.
 
 Routing
 -------
 INVO uses the standard route that is built-in with the :doc:`Router <routing>` component. These routes match the following
 pattern: /:controller/:action/:params. This means that the first part of a URI is the controller, the second the
-action and the rest are the parameters.
+controller action and the rest are the parameters.
 
 The following route `/session/register` executes the controller SessionController and its action registerAction.
 
 Configuration
 -------------
 INVO has a configuration file that sets general parameters in the application. This file is located at
-app/config/config.ini and it's loaded in the very first lines of the application bootstrap (public/index.php):
+app/config/config.ini and is loaded in the very first lines of the application bootstrap (public/index.php):
 
 .. code-block:: php
 
@@ -72,8 +73,8 @@ app/config/config.ini and it's loaded in the very first lines of the application
     );
 
 :doc:`Phalcon\\Config <config>` allows us to manipulate the file in an object-oriented way.
-In this example, we're using a ini file as configuration, however, there are more adapters supported
-for configuration files. The configuration file contains the following settings:
+In this example, we're using an ini file for configuration but Phalcon has :doc:`adapters <config>` for other file types
+as well. The configuration file contains the following settings:
 
 .. code-block:: ini
 
@@ -92,8 +93,8 @@ for configuration files. The configuration file contains the following settings:
     libraryDir     = app/library/
     baseUri        = /invo/
 
-Phalcon hasn't any pre-defined convention settings. Sections help us to organize the options as appropriate.
-In this file there are two sections to be used later "application" and "database".
+Phalcon doesn't have any pre-defined settings convention. Sections help us to organize the options as appropriate.
+In this file there are two sections to be used later: "application" and "database".
 
 Autoloaders
 -----------
@@ -109,7 +110,7 @@ The second part that appears in the bootstrap file (public/index.php) is the aut
     require APP_PATH . "app/config/loader.php";
 
 The autoloader registers a set of directories in which the application will look for
-the classes that it eventually will need.
+the classes that it will eventually need.
 
 .. code-block:: php
 
@@ -131,9 +132,9 @@ the classes that it eventually will need.
     $loader->register();
 
 Note that the above code has registered the directories that were defined in the configuration file. The only
-directory that is not registered is the viewsDir, because it contains HTML + PHP files but no classes.
-Also, note that we have using a constant called APP_PATH, this constant is defined in the bootstrap
-(public/index.php) to allow us have a reference to the root of our project:
+directory that is not registered is the viewsDir because it contains HTML + PHP files but no classes.
+Also, note that we use a constant called APP_PATH. This constant is defined in the bootstrap
+(public/index.php) to allow us to have a reference to the root of our project:
 
 .. code-block:: php
 
@@ -148,8 +149,8 @@ Also, note that we have using a constant called APP_PATH, this constant is defin
 
 Registering services
 --------------------
-Another file that is required in the bootstrap is (app/config/services.php). This file allow
-us to organize the services that INVO does use.
+Another file that is required in the bootstrap is (app/config/services.php). This file allows
+us to organize the services that INVO uses.
 
 .. code-block:: php
 
@@ -160,7 +161,7 @@ us to organize the services that INVO does use.
      */
     require APP_PATH . "app/config/services.php";
 
-Service registration is achieved as in the previous tutorial, making use of a closure to lazily loads
+Service registration is achieved as in the previous tutorial, making use of closures to lazily load
 the required components:
 
 .. code-block:: php
@@ -210,10 +211,10 @@ which initializes and executes all that is necessary to make the application run
 
 Dependency Injection
 --------------------
-Look at the first line of the code block above, the Application class constructor is receiving the variable
-:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework,
+In the first line of the code block above, the Application class constructor is receiving the variable
+:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework
 so we need a component that acts as glue to make everything work together. That component is :doc:`Phalcon\\Di <../api/Phalcon_Di>`.
-It is a service container that also performs dependency injection and service location,
+It's a service container that also performs dependency injection and service location,
 instantiating all components as they are needed by the application.
 
 There are many ways of registering services in the container. In INVO, most services have been registered using
@@ -267,7 +268,7 @@ It registers the majority of services with components provided by the framework 
 the definition of some service we could just set it again as we did above with "session" or "url".
 This is the reason for the existence of the variable :code:`$di`.
 
-In next chapter, we will see how to authentication and authorization is implemented in INVO.
+In next chapter, we will see how authentication and authorization is implemented in INVO.
 
 .. _Github: https://github.com/phalcon/invo
 .. _Bootstrap: http://getbootstrap.com/

--- a/pt/reference/tutorial-invo.rst
+++ b/pt/reference/tutorial-invo.rst
@@ -1,12 +1,13 @@
 Tutorial 2: Introducing INVO
 ============================
 
-In this second tutorial, we'll explain a more complete application in order to deepen the development with Phalcon.
-INVO is one of the applications we have created as samples. INVO is a small website that allows their users to
-generate invoices, and do other tasks such as manage their customers and products. You can clone its code from Github_.
+In this second tutorial, we'll explain a more complete application in order to gain a deeper understanding of
+developing with Phalcon. INVO is one of the sample applications we have created. INVO is a small website that
+allows users to generate invoices and do other tasks such as manage customers and products. You can clone its
+code from Github_.
 
-Also, INVO was made with `Bootstrap`_ as client-side framework. Although the application does not generate
-invoices, it still serves as an example to understand how the framework works.
+INVO was made with the client-side framework `Bootstrap`_. Although the application does not generate actual
+invoices, it still serves as an example showing how the framework works.
 
 Project Structure
 -----------------
@@ -34,29 +35,29 @@ Once you clone the project in your document root you'll see the following struct
         schemas/
 
 As you know, Phalcon does not impose a particular file structure for application development. This project
-provides a simple MVC structure and a public document root.
+has a simple MVC structure and a public document root.
 
 Once you open the application in your browser http://localhost/invo you'll see something like this:
 
 .. figure:: ../_static/img/invo-1.png
    :align: center
 
-The application is divided into two parts, a frontend, that is a public part where visitors can receive information
-about INVO and request contact information. The second part is the backend, an administrative area where a
-registered user can manage his/her products and customers.
+The application is divided into two parts: a frontend and a backend. The frontend is a public area where
+visitors can receive information about INVO and request contact information. The backend is an
+administrative area where registered users can manage their products and customers.
 
 Routing
 -------
 INVO uses the standard route that is built-in with the :doc:`Router <routing>` component. These routes match the following
 pattern: /:controller/:action/:params. This means that the first part of a URI is the controller, the second the
-action and the rest are the parameters.
+controller action and the rest are the parameters.
 
 The following route `/session/register` executes the controller SessionController and its action registerAction.
 
 Configuration
 -------------
 INVO has a configuration file that sets general parameters in the application. This file is located at
-app/config/config.ini and it's loaded in the very first lines of the application bootstrap (public/index.php):
+app/config/config.ini and is loaded in the very first lines of the application bootstrap (public/index.php):
 
 .. code-block:: php
 
@@ -72,8 +73,8 @@ app/config/config.ini and it's loaded in the very first lines of the application
     );
 
 :doc:`Phalcon\\Config <config>` allows us to manipulate the file in an object-oriented way.
-In this example, we're using a ini file as configuration, however, there are more adapters supported
-for configuration files. The configuration file contains the following settings:
+In this example, we're using an ini file for configuration but Phalcon has :doc:`adapters <config>` for other file types
+as well. The configuration file contains the following settings:
 
 .. code-block:: ini
 
@@ -92,8 +93,8 @@ for configuration files. The configuration file contains the following settings:
     libraryDir     = app/library/
     baseUri        = /invo/
 
-Phalcon hasn't any pre-defined convention settings. Sections help us to organize the options as appropriate.
-In this file there are two sections to be used later "application" and "database".
+Phalcon doesn't have any pre-defined settings convention. Sections help us to organize the options as appropriate.
+In this file there are two sections to be used later: "application" and "database".
 
 Autoloaders
 -----------
@@ -109,7 +110,7 @@ The second part that appears in the bootstrap file (public/index.php) is the aut
     require APP_PATH . "app/config/loader.php";
 
 The autoloader registers a set of directories in which the application will look for
-the classes that it eventually will need.
+the classes that it will eventually need.
 
 .. code-block:: php
 
@@ -131,9 +132,9 @@ the classes that it eventually will need.
     $loader->register();
 
 Note that the above code has registered the directories that were defined in the configuration file. The only
-directory that is not registered is the viewsDir, because it contains HTML + PHP files but no classes.
-Also, note that we have using a constant called APP_PATH, this constant is defined in the bootstrap
-(public/index.php) to allow us have a reference to the root of our project:
+directory that is not registered is the viewsDir because it contains HTML + PHP files but no classes.
+Also, note that we use a constant called APP_PATH. This constant is defined in the bootstrap
+(public/index.php) to allow us to have a reference to the root of our project:
 
 .. code-block:: php
 
@@ -148,8 +149,8 @@ Also, note that we have using a constant called APP_PATH, this constant is defin
 
 Registering services
 --------------------
-Another file that is required in the bootstrap is (app/config/services.php). This file allow
-us to organize the services that INVO does use.
+Another file that is required in the bootstrap is (app/config/services.php). This file allows
+us to organize the services that INVO uses.
 
 .. code-block:: php
 
@@ -160,7 +161,7 @@ us to organize the services that INVO does use.
      */
     require APP_PATH . "app/config/services.php";
 
-Service registration is achieved as in the previous tutorial, making use of a closure to lazily loads
+Service registration is achieved as in the previous tutorial, making use of closures to lazily load
 the required components:
 
 .. code-block:: php
@@ -210,10 +211,10 @@ which initializes and executes all that is necessary to make the application run
 
 Dependency Injection
 --------------------
-Look at the first line of the code block above, the Application class constructor is receiving the variable
-:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework,
+In the first line of the code block above, the Application class constructor is receiving the variable
+:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework
 so we need a component that acts as glue to make everything work together. That component is :doc:`Phalcon\\Di <../api/Phalcon_Di>`.
-It is a service container that also performs dependency injection and service location,
+It's a service container that also performs dependency injection and service location,
 instantiating all components as they are needed by the application.
 
 There are many ways of registering services in the container. In INVO, most services have been registered using
@@ -267,7 +268,7 @@ It registers the majority of services with components provided by the framework 
 the definition of some service we could just set it again as we did above with "session" or "url".
 This is the reason for the existence of the variable :code:`$di`.
 
-In next chapter, we will see how to authentication and authorization is implemented in INVO.
+In next chapter, we will see how authentication and authorization is implemented in INVO.
 
 .. _Github: https://github.com/phalcon/invo
 .. _Bootstrap: http://getbootstrap.com/

--- a/uk/reference/tutorial-invo.rst
+++ b/uk/reference/tutorial-invo.rst
@@ -1,12 +1,13 @@
 Tutorial 2: Introducing INVO
 ============================
 
-In this second tutorial, we'll explain a more complete application in order to deepen the development with Phalcon.
-INVO is one of the applications we have created as samples. INVO is a small website that allows their users to
-generate invoices, and do other tasks such as manage their customers and products. You can clone its code from Github_.
+In this second tutorial, we'll explain a more complete application in order to gain a deeper understanding of
+developing with Phalcon. INVO is one of the sample applications we have created. INVO is a small website that
+allows users to generate invoices and do other tasks such as manage customers and products. You can clone its
+code from Github_.
 
-Also, INVO was made with `Bootstrap`_ as client-side framework. Although the application does not generate
-invoices, it still serves as an example to understand how the framework works.
+INVO was made with the client-side framework `Bootstrap`_. Although the application does not generate actual
+invoices, it still serves as an example showing how the framework works.
 
 Project Structure
 -----------------
@@ -34,29 +35,29 @@ Once you clone the project in your document root you'll see the following struct
         schemas/
 
 As you know, Phalcon does not impose a particular file structure for application development. This project
-provides a simple MVC structure and a public document root.
+has a simple MVC structure and a public document root.
 
 Once you open the application in your browser http://localhost/invo you'll see something like this:
 
 .. figure:: ../_static/img/invo-1.png
    :align: center
 
-The application is divided into two parts, a frontend, that is a public part where visitors can receive information
-about INVO and request contact information. The second part is the backend, an administrative area where a
-registered user can manage his/her products and customers.
+The application is divided into two parts: a frontend and a backend. The frontend is a public area where
+visitors can receive information about INVO and request contact information. The backend is an
+administrative area where registered users can manage their products and customers.
 
 Routing
 -------
 INVO uses the standard route that is built-in with the :doc:`Router <routing>` component. These routes match the following
 pattern: /:controller/:action/:params. This means that the first part of a URI is the controller, the second the
-action and the rest are the parameters.
+controller action and the rest are the parameters.
 
 The following route `/session/register` executes the controller SessionController and its action registerAction.
 
 Configuration
 -------------
 INVO has a configuration file that sets general parameters in the application. This file is located at
-app/config/config.ini and it's loaded in the very first lines of the application bootstrap (public/index.php):
+app/config/config.ini and is loaded in the very first lines of the application bootstrap (public/index.php):
 
 .. code-block:: php
 
@@ -72,8 +73,8 @@ app/config/config.ini and it's loaded in the very first lines of the application
     );
 
 :doc:`Phalcon\\Config <config>` allows us to manipulate the file in an object-oriented way.
-In this example, we're using a ini file as configuration, however, there are more adapters supported
-for configuration files. The configuration file contains the following settings:
+In this example, we're using an ini file for configuration but Phalcon has :doc:`adapters <config>` for other file types
+as well. The configuration file contains the following settings:
 
 .. code-block:: ini
 
@@ -92,8 +93,8 @@ for configuration files. The configuration file contains the following settings:
     libraryDir     = app/library/
     baseUri        = /invo/
 
-Phalcon hasn't any pre-defined convention settings. Sections help us to organize the options as appropriate.
-In this file there are two sections to be used later "application" and "database".
+Phalcon doesn't have any pre-defined settings convention. Sections help us to organize the options as appropriate.
+In this file there are two sections to be used later: "application" and "database".
 
 Autoloaders
 -----------
@@ -109,7 +110,7 @@ The second part that appears in the bootstrap file (public/index.php) is the aut
     require APP_PATH . "app/config/loader.php";
 
 The autoloader registers a set of directories in which the application will look for
-the classes that it eventually will need.
+the classes that it will eventually need.
 
 .. code-block:: php
 
@@ -131,9 +132,9 @@ the classes that it eventually will need.
     $loader->register();
 
 Note that the above code has registered the directories that were defined in the configuration file. The only
-directory that is not registered is the viewsDir, because it contains HTML + PHP files but no classes.
-Also, note that we have using a constant called APP_PATH, this constant is defined in the bootstrap
-(public/index.php) to allow us have a reference to the root of our project:
+directory that is not registered is the viewsDir because it contains HTML + PHP files but no classes.
+Also, note that we use a constant called APP_PATH. This constant is defined in the bootstrap
+(public/index.php) to allow us to have a reference to the root of our project:
 
 .. code-block:: php
 
@@ -148,8 +149,8 @@ Also, note that we have using a constant called APP_PATH, this constant is defin
 
 Registering services
 --------------------
-Another file that is required in the bootstrap is (app/config/services.php). This file allow
-us to organize the services that INVO does use.
+Another file that is required in the bootstrap is (app/config/services.php). This file allows
+us to organize the services that INVO uses.
 
 .. code-block:: php
 
@@ -160,7 +161,7 @@ us to organize the services that INVO does use.
      */
     require APP_PATH . "app/config/services.php";
 
-Service registration is achieved as in the previous tutorial, making use of a closure to lazily loads
+Service registration is achieved as in the previous tutorial, making use of closures to lazily load
 the required components:
 
 .. code-block:: php
@@ -210,10 +211,10 @@ which initializes and executes all that is necessary to make the application run
 
 Dependency Injection
 --------------------
-Look at the first line of the code block above, the Application class constructor is receiving the variable
-:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework,
+In the first line of the code block above, the Application class constructor is receiving the variable
+:code:`$di` as an argument. What is the purpose of that variable? Phalcon is a highly decoupled framework
 so we need a component that acts as glue to make everything work together. That component is :doc:`Phalcon\\Di <../api/Phalcon_Di>`.
-It is a service container that also performs dependency injection and service location,
+It's a service container that also performs dependency injection and service location,
 instantiating all components as they are needed by the application.
 
 There are many ways of registering services in the container. In INVO, most services have been registered using
@@ -267,7 +268,7 @@ It registers the majority of services with components provided by the framework 
 the definition of some service we could just set it again as we did above with "session" or "url".
 This is the reason for the existence of the variable :code:`$di`.
 
-In next chapter, we will see how to authentication and authorization is implemented in INVO.
+In next chapter, we will see how authentication and authorization is implemented in INVO.
 
 .. _Github: https://github.com/phalcon/invo
 .. _Bootstrap: http://getbootstrap.com/


### PR DESCRIPTION
This pull request fixes some English problems found in the [tutorial-invo](https://docs.phalconphp.com/en/latest/reference/tutorial-invo.html) page. To maintain consistency, I made the changes in all versions that are currently in English.    

I also added a link to the config doc page [here](https://github.com/phalcon/docs/compare/master...zachleigh:fix-tutorial-invo-english?expand=1#diff-d4c01d64a44415292b58b57cb90b56fcR76). When I read this the first time, I wanted to read more about what file types are supported.