### PR TITLE
Fix events setEventManager typehint.

### DIFF
--- a/en/reference/events.rst
+++ b/en/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/es/reference/events.rst
+++ b/es/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/fa/reference/events.rst
+++ b/fa/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/fr/reference/events.rst
+++ b/fr/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/id/reference/events.rst
+++ b/id/reference/events.rst
@@ -160,14 +160,14 @@ Komponen ini peduli EventsManager (ia mengimplementasi :doc:`Phalcon\\Events\\Ev
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/ja/reference/events.rst
+++ b/ja/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/pl/reference/events.rst
+++ b/pl/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/pt/reference/events.rst
+++ b/pt/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/ru/reference/events.rst
+++ b/ru/reference/events.rst
@@ -160,14 +160,14 @@ Attaching an event listener to the events manager is as simple as:
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/uk/reference/events.rst
+++ b/uk/reference/events.rst
@@ -160,14 +160,14 @@ This component is EventsManager aware (it implements :doc:`Phalcon\\Events\\Even
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }

--- a/zh/reference/events.rst
+++ b/zh/reference/events.rst
@@ -159,14 +159,14 @@ Attaching an event listener to the events manager is as simple as:
 
     <?php
 
+    use Phalcon\Events\ManagerInterface;
     use Phalcon\Events\EventsAwareInterface;
-    use Phalcon\Events\Manager as EventsManager;
 
     class MyComponent implements EventsAwareInterface
     {
         protected $_eventsManager;
 
-        public function setEventsManager(EventsManager $eventsManager)
+        public function setEventsManager(ManagerInterface $eventsManager)
         {
             $this->_eventsManager = $eventsManager;
         }


### PR DESCRIPTION
Currently, in the 'Creating Components That Trigger Events' section, the docs suggest typehinting the event manager like this:
```php
use Phalcon\Events\Manager as EventsManager;

public function setEventsManager(EventsManager $eventsManager)
{
    $this->_eventsManager = $eventsManager;
}
```
This produces a fatal php error because the interface Phalcon\Events\EventsAwareInterface has the following method signature:
```php
abstract public setEventsManager (Phalcon\Events\ManagerInterface $eventsManager)
```
Refrence: https://docs.phalconphp.com/en/latest/api/Phalcon_Events_EventsAwareInterface.html    

I've updated the docs in all languages to correctly typehint the ManagerInterface.