### PR TITLE
fix description of filter "slashes" in volt docs (the PHP function is…

### DIFF
--- a/en/reference/volt.rst
+++ b/en/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/es/reference/volt.rst
+++ b/es/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/fa/reference/volt.rst
+++ b/fa/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/fr/reference/volt.rst
+++ b/fr/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/id/reference/volt.rst
+++ b/id/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/ja/reference/volt.rst
+++ b/ja/reference/volt.rst
@@ -291,7 +291,7 @@ views directory. The following examples show how to change the compilation path 
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/pl/reference/volt.rst
+++ b/pl/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/pt/reference/volt.rst
+++ b/pt/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/uk/reference/volt.rst
+++ b/uk/reference/volt.rst
@@ -302,7 +302,7 @@ The following is the list of available built-in filters in Volt:
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+

--- a/zh/reference/volt.rst
+++ b/zh/reference/volt.rst
@@ -297,7 +297,7 @@ views directory. The following examples show how to change the compilation path 
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`striptags`        | Applies the striptags_ PHP function to the value. Removing HTML tags         |
 +--------------------------+------------------------------------------------------------------------------+
-| :code:`slashes`          | Applies the slashes_ PHP function to the value. Escaping values              |
+| :code:`slashes`          | Applies the addslashes_ PHP function to the value. Escaping values              |
 +--------------------------+------------------------------------------------------------------------------+
 | :code:`stripslashes`     | Applies the stripslashes_ PHP function to the value. Removing escaped quotes |
 +--------------------------+------------------------------------------------------------------------------+


### PR DESCRIPTION
… addslashes instead of slashes).

Fix all languages. Only russian was correct.