### PR TITLE
Mac Tools has been translated into Portuguese

### DIFF
--- a/pt/reference/crypt.rst
+++ b/pt/reference/crypt.rst
@@ -7,8 +7,8 @@ Essa classe oferece uma simples camada orientada a objetos baseada na biblioteca
 Por padrão, esse componente provê uma encriptação segura usando AES-256.
 
 .. highlights::
-    You must use a key length corresponding to the current algorithm.
-    For the algorithm used by default it is 32 bytes.
+    Você deve usar um comprimento de chave correspondente ao algoritmo atual. 
+    Para o algoritmo usado por padrão é 32 bytes.
 
 Uso Básico
 ----------

--- a/pt/reference/mactools.rst
+++ b/pt/reference/mactools.rst
@@ -1,28 +1,28 @@
-Phalcon Developer Tools on Mac OS X
+Phalcon Developer Tools no Mac OS X
 ===================================
 
-These steps will guide you through the process of installing Phalcon Developer Tools for OS/X.
+Estas medidas irão guiá-lo através do processo de instalação da Phalcon Developer Tools para OS/X.
 
-Prerequisites
--------------
-The Phalcon PHP extension is required to run Phalcon Tools. If you haven't installed it yet, please see the :doc:`Installation <install>` section for instructions.
+Pré-requisitos
+--------------
+A extensão Phalcon PHP é necessário para executar Phalcon Tools. Se você ainda não tiver instalado, por favor consulte o: doc:`Instalação <install>` seção para obter instruções.
 
 Download
 --------
-You can download a cross platform package containing the developer tools from the `Download`_ section. You can also clone it from `Github`_.
+Você pode baixar um pacote da plataforma que contém as ferramentas de desenvolvimento a partir da seção Download_ . Também você pode cloná-lo do Github_.
 
-Open the terminal application:
+Abra o aplicativo de terminal:
 
 .. figure:: ../_static/img/mac-1.png
    :align: center
 
-Copy & Paste the commands below in your terminal:
+Copie e cole os comandos abaixo em seu terminal:
 
 .. code-block:: bash
 
     git clone git://github.com/phalcon/phalcon-devtools.git
 
-Then enter the folder where the tools were cloned and execute ". ./phalcon.sh", (don't forget the dot at beginning of the command):
+Em seguida, digite a pasta onde as ferramentas foram clonadas e execute "./phalcon.sh", (não se esqueça do ponto no início do comando):
 
 .. code-block:: bash
 
@@ -30,7 +30,7 @@ Then enter the folder where the tools were cloned and execute ". ./phalcon.sh", 
 
     . ./phalcon.sh
 
-In the terminal window, type the following commands to create a symbolic link to the phalcon.php script:
+Na janela do terminal, digite os seguintes comandos para criar um link simbólico para o script phalcon.php:
 
 .. code-block:: bash
 
@@ -38,14 +38,14 @@ In the terminal window, type the following commands to create a symbolic link to
 
     chmod +x ~/phalcon-tools/phalcon
 
-Type the command "phalcon" and you will see something like this:
+Digite o comando "phalcon" e você verá algo como isto:
 
 .. figure:: ../_static/img/mac-5.png
    :align: center
 
-Congratulations you now have Phalcon tools installed!
+Parabéns, agora você tem instalado a Phalcon tools!
 
-Related Guides
+Guias Relacionados
 ^^^^^^^^^^^^^^
 * :doc:`Using Developer Tools <tools>`
 * :doc:`Installation on Windows <wintools>`

--- a/pt/reference/mactools.rst
+++ b/pt/reference/mactools.rst
@@ -5,7 +5,7 @@ Estas medidas irão guiá-lo através do processo de instalação da Phalcon Dev
 
 Pré-requisitos
 --------------
-A extensão Phalcon PHP é necessário para executar Phalcon Tools. Se você ainda não tiver instalado, por favor consulte o: doc:`Instalação <install>` seção para obter instruções.
+A extensão Phalcon PHP é necessário para executar Phalcon Tools. Se você ainda não tiver instalado, por favor consulte a seção :doc:`Installation <install>` para obter instruções.
 
 Download
 --------

--- a/pt/reference/mactools.rst
+++ b/pt/reference/mactools.rst
@@ -46,7 +46,7 @@ Digite o comando "phalcon" e você verá algo como isto:
 Parabéns, agora você tem instalado a Phalcon tools!
 
 Guias Relacionados
-^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 * :doc:`Using Developer Tools <tools>`
 * :doc:`Installation on Windows <wintools>`
 * :doc:`Installation on Linux <linuxtools>`

--- a/pt/reference/mactools.rst
+++ b/pt/reference/mactools.rst
@@ -22,7 +22,7 @@ Copie e cole os comandos abaixo em seu terminal:
 
     git clone git://github.com/phalcon/phalcon-devtools.git
 
-Em seguida, digite a pasta onde as ferramentas foram clonadas e execute "./phalcon.sh", (não se esqueça do ponto no início do comando):
+Em seguida, digite a pasta onde as ferramentas foram clonadas e execute ". ./phalcon.sh", (não se esqueça do ponto no início do comando):
 
 .. code-block:: bash
 

--- a/pt/reference/pagination.rst
+++ b/pt/reference/pagination.rst
@@ -1,12 +1,11 @@
-Pagination
-==========
+Paginação
+=========
 
-The process of pagination takes place when we need to present big groups of arbitrary data gradually. :code:`Phalcon\Paginator` offers a
-fast and convenient way to split these sets of data into browsable pages.
+The process of pagination takes place when we need to present big groups of arbitrary data gradually. :code:`Phalcon\Paginator` oferece uma maneira rápida e conveniente de dividir esses conjuntos de dados em páginas navegáveis.
 
-Data Adapters
--------------
-This component makes use of adapters to encapsulate different sources of data:
+Adaptadores de Dados
+--------------------
+Este componente faz uso de adaptadores para encapsular diferentes fontes de dados:
 
 +--------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Adapter                                                                                          | Description                                                                                                                                                                                                               |
@@ -18,9 +17,9 @@ This component makes use of adapters to encapsulate different sources of data:
 | :doc:`Phalcon\\Paginator\\Adapter\\QueryBuilder <../api/Phalcon_Paginator_Adapter_QueryBuilder>` | Use a :doc:`Phalcon\\Mvc\\Model\\Query\\Builder <../api/Phalcon_Mvc_Model_Query_Builder>` object as source data                                                                                                           |
 +--------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Examples
+Exemplos
 --------
-In the example below, the paginator will use the result of a query from a model as its source data, and limit the displayed data to 10 records per page:
+No exemplo abaixo, o paginador usará o resultado de uma consulta de um modelo como seus dados de origem e limitará os dados exibidos a 10 registros por página:
 
 .. code-block:: php
 
@@ -49,8 +48,8 @@ In the example below, the paginator will use the result of a query from a model 
     // Get the paginated results
     $page = $paginator->getPaginate();
 
-The :code:`$currentPage` variable controls the page to be displayed. The :code:`$paginator->getPaginate()` returns a :code:`$page`
-object that contains the paginated data. It can be used for generating the pagination:
+A variável :code:`$currentPage` controla a página a ser exibida. :code:`$paginator->getPaginate()` retorna um objeto :code:`$page`
+que contém os dados paginados. Ele pode ser usado para gerar a paginação:
 
 .. code-block:: html+php
 
@@ -69,7 +68,7 @@ object that contains the paginated data. It can be used for generating the pagin
         <?php } ?>
     </table>
 
-The :code:`$page` object also contains navigation data:
+O objeto :code:`$page` também contém dados de navegação:
 
 .. code-block:: html+php
 
@@ -80,9 +79,9 @@ The :code:`$page` object also contains navigation data:
 
     <?php echo "You are in page ", $page->current, " of ", $page->total_pages; ?>
 
-Adapters Usage
---------------
-An example of the source data that must be used for each adapter:
+Uso de Adaptadores
+------------------
+Um exemplo dos dados de origem que devem ser usados para cada adaptador:
 
 .. code-block:: php
 
@@ -131,31 +130,31 @@ An example of the source data that must be used for each adapter:
         ]
     );
 
-Page Attributes
----------------
-The :code:`$page` object has the following attributes:
+Atributos de Página
+-------------------
+O objeto :code:`$page` possui os seguintes atributos
 
 +-------------+--------------------------------------------------------+
-| Attribute   | Description                                            |
+| Atributo    | Descrição                                              |
 +=============+========================================================+
-| items       | The set of records to be displayed at the current page |
+| items       | O conjunto de registros a ser exibido na página atual  |
 +-------------+--------------------------------------------------------+
-| current     | The current page                                       |
+| current     | A página atual                                         |
 +-------------+--------------------------------------------------------+
-| before      | The previous page to the current one                   |
+| before      | A página anterior à atual                              |
 +-------------+--------------------------------------------------------+
-| next        | The next page to the current one                       |
+| next        | A próxima página para a atual                          |
 +-------------+--------------------------------------------------------+
-| last        | The last page in the set of records                    |
+| last        | A última página no conjunto de registros               |
 +-------------+--------------------------------------------------------+
-| total_pages | The number of pages                                    |
+| total_pages | O número de páginas                                    |
 +-------------+--------------------------------------------------------+
-| total_items | The number of items in the source data                 |
+| total_items | O número de itens nos dados de origem                  |
 +-------------+--------------------------------------------------------+
 
-Implementing your own adapters
-------------------------------
-The :doc:`Phalcon\\Paginator\\AdapterInterface <../api/Phalcon_Paginator_AdapterInterface>` interface must be implemented in order to create your own paginator adapters or extend the existing ones:
+Implementando seus próprios adaptadores
+---------------------------------------
+A interface :doc:`Phalcon\\Paginator\\AdapterInterface <../api/Phalcon_Paginator_AdapterInterface>` deve ser implementada para criar seus próprios adaptadores, paginadores ou estender os existentes:
 
 .. code-block:: php
 

--- a/pt/reference/wintools.rst
+++ b/pt/reference/wintools.rst
@@ -67,8 +67,8 @@ Congratulations you now have Phalcon tools installed!
 
 Parabéns, você agora têm o Phalcon tools instalado!
 
-Related Guides
-^^^^^^^^^^^^^^
+Guias Relacionados
+^^^^^^^^^^^^^^^^^^
 * :doc:`Using Developer Tools <tools>`
 * :doc:`Installation on OS X <mactools>`
 * :doc:`Installation on Linux <linuxtools>`


### PR DESCRIPTION
The File: mactools.rst has been translated into portuguese.
Already the file: wintools.rst, a small improvement has been made.