### PR TITLE
Improving section on magic methods docblock

### DIFF
--- a/en/reference/model-relationships.rst
+++ b/en/reference/model-relationships.rst
@@ -451,9 +451,9 @@ With the aliasing we can get the related records easily:
 
 Magic Getters vs. Explicit methods
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Most IDEs and editors with auto-completion capabilities can not infer the correct types when using magic getters,
-instead of use the magic getters you can optionally define those methods explicitly with the corresponding
-docblocks helping the IDE to produce a better auto-completion:
+Most IDEs and editors with auto-completion capabilities can not infer the correct types when using magic getters
+(both methods and properties). To overcome that, you can use a class docblock that specifies what magic actions are
+available, helping the IDE to produce a better auto-completion:
 
 .. code-block:: php
 
@@ -463,6 +463,12 @@ docblocks helping the IDE to produce a better auto-completion:
 
     use Phalcon\Mvc\Model;
 
+    /**
+     * Model class for the robots table.
+     * @property Simple|RobotsParts[] $robotsParts
+     * @method   Simple|RobotsParts[] getRobotsParts($parameters = null)
+     * @method   integer              countRobotsParts()
+     */
     class Robots extends Model
     {
         public $id;
@@ -476,16 +482,6 @@ docblocks helping the IDE to produce a better auto-completion:
                 "RobotsParts",
                 "robots_id"
             );
-        }
-
-        /**
-         * Return the related "robots parts"
-         *
-         * @return \RobotsParts[]
-         */
-        public function getRobotsParts($parameters = null)
-        {
-            return $this->getRelated("RobotsParts", $parameters);
         }
     }
 


### PR DESCRIPTION
There's no need to suggest the user rewrite the magic method just to get auto-completion on their favourite IDE; there are PHPDoc tags specific to document magic methods. We should incentivize the use of @method and @property, instead of an error-prone copy-pasta of the dynamic framework behaviour.