### PR TITLE
Webserver documentation Revision

### DIFF
--- a/en/webserver-setup.md
+++ b/en/webserver-setup.md
@@ -4,6 +4,14 @@
       <a href="#setup">Web Server Setup</a> 
       <ul>
         <li>
+          <a href="#php-built-in">Built in Webserver</a> 
+          <ul>
+            <li>
+              <a href="#php-built-in-phalcon-configuration">Phalcon configuration</a>
+            </li>
+          </ul>
+        </li>
+        <li>
           <a href="#nginx">Nginx</a> 
           <ul>
             <li>
@@ -42,14 +50,6 @@
             </li>
           </ul>
         </li>
-        <li>
-          <a href="#php-built-in">Built in Webserver</a> 
-          <ul>
-            <li>
-              <a href="#php-built-in-phalcon-configuration">Phalcon configuration</a>
-            </li>
-          </ul>
-        </li>
       </ul>
     </li>
   </ul>
@@ -59,73 +59,113 @@
 # Web Server Setup
 In order for the routing of the Phalcon application to work, you will need to set up your web server to process the redirects properly. Setup instructions for popular web servers are:
 
+<a name='php-fpm'></a>
+## PHP-FPM
+The [PHP-FPM](http://php.net/manual/en/install.fpm.php) (FastCGI Process Manager) is usually used to allow the processing of PHP files. Nowadays, PHP-FPM is bundled with all Linux based PHP distributions.
+
+On **Windows** PHP-FPM is in the PHP distribution archive through the file `php-cgi.exe` and you can start it with this script to help set options. Windows does not support unix sockets so this script will start fast-cgi in TCP mode on port `9000`.
+
+Create the file `php-fcgi.bat` with the following contents:
+
+```bat
+@ECHO OFF
+ECHO Starting PHP FastCGI...
+set PATH=C:\PHP;%PATH%
+c:\bin\RunHiddenConsole.exe C:\PHP\php-cgi.exe -b 127.0.0.1:9000
+```
+
+<a name='php-built-in'></a>
+## PHP Built-In Webserver (For Developers)
+To speed up getting your Phalcon application running in development the easiest way is to use this built-in PHP server. Do not use this server in a production environment. The following configurations for [Nginx](#nginx) and [Apache](#apache) are what you need.
+
+<a name='php-built-in-phalcon-configuration'></a>
+### Phalcon configuration
+To enable dynamic URI rewrites, without Apache or Nginx, that Phalcon needs, you can use the following router file:
+<a href="https://github.com/phalcon/phalcon-devtools/blob/master/templates/.htrouter.php" target="_blank">.htrouter.php</a>
+
+If you created your application with [Phalcon-Devtools](/[[language]]/[[version]]/devtools-installation) this file should already exist in the root directory of your project and you can start the server with the following command:
+
+```bash
+$(which php) -S localhost:8000 -t public .htrouter.php
+```
+
+The anatomy of the command above:
+- `$(which php)` - will insert the absolute path to your PHP binary
+- `-S localhost:8000` - invokes server mode with the provided `host:port`
+- `-t public` - defines the servers root directory, necessary for php to route requests to assets like JS, CSS, and images in your public directory
+- `.htrouter.php` - the entry point that will be evaluated for each request
+
+Then point your browser to http://localhost:8000/ to check if everything is working.
+
 <a name='nginx'></a>
 ## Nginx
 [Nginx](http://wiki.nginx.org/Main) is a free, open-source, high-performance HTTP server and reverse proxy, as well as an IMAP/POP3 proxy server. Unlike traditional servers, Nginx doesn't rely on threads to handle requests. Instead it uses a much more scalable event-driven (asynchronous) architecture. This architecture uses small, but more importantly, predictable amounts of memory under load.
 
-The [PHP-FPM](http://php-fpm.org/) (FastCGI Process Manager) is usually used to allow Nginx to process PHP files. Nowadays, PHP-FPM is bundled with all Linux based PHP distributions. Phalcon with Nginx and PHP-FPM provide a powerful set of tools that offer maximum performance for your PHP applications.
+Phalcon with Nginx and PHP-FPM provide a powerful set of tools that offer maximum performance for your PHP applications.
+
+### Install Nginx
+<a href="https://www.nginx.com/resources/wiki/start/topics/tutorials/install/" target="_blank">NginX Offical Site</a>
 
 <a name='nginx-phalcon-configuration'></a>
 ### Phalcon configuration
-The following are potential configurations you can use to setup Nginx with Phalcon:
-
-<a name='nginx-phalcon-configuration-basic'></a>
-#### Basic configuration
-Using `$_GET['_url']` as source of URIs:
+You can use following potential configuration to setup Nginx with Phalcon:
 
 ```nginx
 server {
-    listen      80;
-    server_name localhost.dev;
+    # Port 80 will require Nginx to be started with root permissions
+    # Depending on how you install Nginx to use port 80 you will need
+    # to start the server with `sudo` ports about 1000 do not require
+    # root privileges
+    # listen      80;
+
+    listen        8000;
+    server_name   default;
+
+    ##########################
+    # In production require SSL
+    # listen 443 ssl default_server;
+
+    # ssl on;
+    # ssl_session_timeout  5m;
+    # ssl_protocols  SSLv2 SSLv3 TLSv1;
+    # ssl_ciphers  ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv2:+EXP;
+    # ssl_prefer_server_ciphers   on;
+
+    # These locations depend on where you store your certs
+    # ssl_certificate        /var/nginx/certs/default.cert;
+    # ssl_certificate_key    /var/nginx/certs/default.key;
+    ##########################
 
     # This is the folder that index.php is in
-    root /var/www/phalcon/public;
+    root /var/www/default/public;
     index index.php index.html index.htm;
 
     charset utf-8;
+    client_max_body_size 100M;
+    fastcgi_read_timeout 1800;
 
+    # Represents the root of the domain
+    # http://localhost:8000/[index.php]
     location / {
+        # Matches URLS `$_GET['_url']`
         try_files $uri $uri/ /index.php?_url=$uri&$args;
     }
 
-    location ~ \.php {
-        fastcgi_pass  unix:/run/php-fpm/php-fpm.sock;
-        fastcgi_index /index.php;
-
-        include fastcgi_params;
-        fastcgi_split_path_info       ^(.+\.php)(/.+)$;
-        fastcgi_param PATH_INFO       $fastcgi_path_info;
-        fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-    }
-
-    location ~ /\.ht {
-        deny all;
-    }
-}
-```
-
-Using `$_SERVER['REQUEST_URI']` as source of URIs:
-
-```nginx
-server {
-    listen      80;
-    server_name localhost.dev;
-
-    # This is the folder that index.php is in
-    root /var/www/phalcon/public;
-    index index.php index.html index.htm;
-
-    charset utf-8;
-
-    location / {
-        try_files $uri $uri/ /index.php;
-    }
-
+    # When the HTTP request does not match the above
+    # and the file ends in .php
     location ~ \.php$ {
         try_files $uri =404;
 
-        fastcgi_pass  127.0.0.1:9000;
+        # Ubuntu and PHP7.0-fpm in socket mode
+        # This path is dependent on the version of PHP install
+        fastcgi_pass  unix:/var/run/php/php7.0-fpm.sock;
+
+
+        # Alternatively you use PHP-FPM in TCP mode (Required on Windows)
+        # You will need to configure FPM to listen on a standard port
+        # https://www.nginx.com/resources/wiki/start/topics/examples/phpfastcgionwindows/
+        # fastcgi_pass  127.0.0.1:9000;
+
         fastcgi_index /index.php;
 
         include fastcgi_params;
@@ -138,8 +178,17 @@ server {
     location ~ /\.ht {
         deny all;
     }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires       max;
+        log_not_found off;
+        access_log    off;
+    }
 }
 ```
+
+### Start Nginx
+Usually `start nginx` from the command line but this depends on your installation method.
 
 <a name='apache'></a>
 ## Apache
@@ -283,29 +332,3 @@ Execute the application in a browser:
 
 ![](/images/content/webserver-cherokee-9.jpg)
 
-<a name='php-built-in'></a>
-## PHP Built In Webserver
-You can use PHP's [built in](http://php.net/manual/en/features.commandline.webserver.php) web server for your development. To start the server type:
-```bash
-php -S localhost:8000 -t /public
-```
-
-<a name='php-built-in-phalcon-configuration'></a>
-### Phalcon configuration
-To enable URI rewrites that Phalcon needs, you can use the following router file (`.htrouter.php`):
-```php
-<?php
-
-if (!file_exists(__DIR__ . '/' . $_SERVER['REQUEST_URI'])) {
-    $_GET['_url'] = $_SERVER['REQUEST_URI'];
-}
-
-return false;
-```
-
-and then start the server from the base project directory with:
-```bash
-php -S localhost:8000 -t /public .htrouter.php
-```
-
-Then point your browser to http://localhost:8000/ to check if everything is working.


### PR DESCRIPTION
###### What am I?
Under review of the webserver-setup documentation I noticed it was a little unfocused and while the configurations were correct they did not contain line documentation.
There were a couple of discrepancies between windows and linux NGINX configurations. So I have combined them and kept the focus on linux with associated support for fast cgi and proxy_pass config.

I have also reordered the file to put the `built-in` server documentation first. No one is going to get to the NGINX or apache configuration until they have something to deploy in the meantime to improve framework adoption promoting the lowest weight runtime should be first.

Better yet this configuration is not platform dependent and should hopefully get users running without working about a server at all initially.

@niden I am looking for your feedback. This is still a WIP regarding the nginx configuration which I want to double check before this is merged.