### PR TITLE
Move tutorials higer in the food chain

### DIFF
--- a/en/sidebar.md
+++ b/en/sidebar.md
@@ -14,6 +14,12 @@
     - [Webserver Setup](/[[language]]/[[version]]/webserver-setup)
         - [WAMP](/[[language]]/[[version]]/webserver-wamp)
         - [XAMPP](/[[language]]/[[version]]/webserver-xampp)
+- Tutorials
+    - [Basic](/[[language]]/[[version]]/tutorial-base)
+    - [REST](/[[language]]/[[version]]/tutorial-rest)
+    - [Vokuro](/[[language]]/[[version]]/tutorial-vokuro)
+    - [Performance](/[[language]]/[[version]]/performance)
+    - [Invo](/[[language]]/[[version]]/tutorial-invo)
 - Environments
     - [Phalcon Compose (Docker)](/[[language]]/[[version]]/environments-docker)
     - [Nanobox](/[[language]]/[[version]]/environments-nanobox)
@@ -82,10 +88,3 @@
 - i18n
     - [Internationalization](/[[language]]/[[version]]/i18n)
     - [Translate](/[[language]]/[[version]]/translate)
-- Tutorials
-    - [Performance](/[[language]]/[[version]]/performance)
-    - [Basic](/[[language]]/[[version]]/tutorial-base)
-    - [Invo](/[[language]]/[[version]]/tutorial-invo)
-    - [REST](/[[language]]/[[version]]/tutorial-rest)
-    - [Vokuro](/[[language]]/[[version]]/tutorial-vokuro)
-    


### PR DESCRIPTION
Tutorials is one of the highest requested pages so it should be higher

Move these links below Getting started and reorders them by request priority