### PR TITLE
Fix 1224 Correct missing $ token and duplicate php tags

### DIFF
--- a/en/api/Phalcon_Mvc_Model.md
+++ b/en/api/Phalcon_Mvc_Model.md
@@ -31,7 +31,7 @@ if ($robot->save() === false) {
     $messages = $robot->getMessages();
 
     foreach ($messages as $message) {
-        echo message;
+        echo $message;
     }
 } else {
     echo "Great, a new robot was saved successfully!";
@@ -903,8 +903,6 @@ generated INSERT/UPDATE statement
 ```php
 <?php
 
-<?php
-
 class Robots extends \Phalcon\Mvc\Model
 {
     public function initialize()
@@ -927,8 +925,6 @@ Sets a list of attributes that must be skipped from the
 generated INSERT statement
 
 ```php
-<?php
-
 <?php
 
 class Robots extends \Phalcon\Mvc\Model
@@ -955,8 +951,6 @@ generated UPDATE statement
 ```php
 <?php
 
-<?php
-
 class Robots extends \Phalcon\Mvc\Model
 {
     public function initialize()
@@ -979,8 +973,6 @@ Sets a list of attributes that must be skipped from the
 generated UPDATE statement
 
 ```php
-<?php
-
 <?php
 
 class Robots extends \Phalcon\Mvc\Model
@@ -1006,8 +998,6 @@ Setup a 1-1 relation between two models
 ```php
 <?php
 
-<?php
-
 class Robots extends \Phalcon\Mvc\Model
 {
     public function initialize()
@@ -1025,8 +1015,6 @@ protected  **belongsTo** (*mixed* $fields, *mixed* $referenceModel, *mixed* $ref
 Setup a reverse 1-1 or n-1 relation between two models
 
 ```php
-<?php
-
 <?php
 
 class RobotsParts extends \Phalcon\Mvc\Model
@@ -1048,8 +1036,6 @@ Setup a 1-n relation between two models
 ```php
 <?php
 
-<?php
-
 class Robots extends \Phalcon\Mvc\Model
 {
     public function initialize()
@@ -1067,8 +1053,6 @@ protected [Phalcon\Mvc\Model\Relation](/en/3.1.2/api/Phalcon_Mvc_Model_Relation)
 Setup an n-n relation between two models, through an intermediate relation
 
 ```php
-<?php
-
 <?php
 
 class Robots extends \Phalcon\Mvc\Model
@@ -1096,8 +1080,6 @@ public  **addBehavior** ([Phalcon\Mvc\Model\BehaviorInterface](/en/3.1.2/api/Pha
 Setups a behavior in a model
 
 ```php
-<?php
-
 <?php
 
 use Phalcon\Mvc\Model;
@@ -1129,8 +1111,6 @@ protected  **keepSnapshots** (*mixed* $keepSnapshot)
 Sets if the model must keep the original record snapshot in memory
 
 ```php
-<?php
-
 <?php
 
 use Phalcon\Mvc\Model;
@@ -1197,8 +1177,6 @@ protected  **useDynamicUpdate** (*mixed* $dynamicUpdate)
 Sets if a model must use dynamic update instead of the all-field update
 
 ```php
-<?php
-
 <?php
 
 use Phalcon\Mvc\Model;


### PR DESCRIPTION
###### Closes #1224 

Adds missing `$` token to and removes duplicate `<?php` tags