### PR TITLE
Convert partial vs include bullet list to table.

### DIFF
--- a/en/volt.md
+++ b/en/volt.md
@@ -1077,13 +1077,14 @@ A partial is included in runtime, Volt also provides `include`, this compiles th
 ### Partial vs Include
 Keep the following points in mind when choosing to use the `partial` function or `include`:
 
-* `partial` allows you to include templates made in Volt and in other template engines as well
-* `partial` allows you to pass an expression like a variable allowing to include the content of other view dynamically
-* `partial` is better if the content that you have to include changes frequently
-
-* `include` copies the compiled content into the view which improves the performance
-* `include` only allows to include templates made with Volt
-* `include` requires an existing template at compile time
+| Type          | Description 
+|---------------|-------------------------------------------------------------------------------------------------------------|
+| `partial`     | allows you to include templates made in Volt and in other template engines as well                          |
+|               | allows you to pass an expression like a variable allowing to include the content of other view dynamically  |
+|               | is better if the content that you have to include changes frequently                                        |
+| `includes`    | copies the compiled content into the view which improves the performance                                    |
+|               | only allows to include templates made with Volt                                                             |
+|               | requires an existing template at compile time                                                               |
 
 <a name='template-inheritance'></a>
 ## Template Inheritance


### PR DESCRIPTION
###### Convert `partial` vs `include` bullet list to a table.

closes [https://github.com/phalcon/docs/issues/1230](https://github.com/phalcon/docs/issues/1230)

<img width="708" alt="screen shot 2017-08-31 at 10 30 01 am" src="https://user-images.githubusercontent.com/13909325/29928733-a00bff78-8e37-11e7-8a72-309d634033c4.png">

