### PR TITLE
Fix link to testing guide

### DIFF
--- a/en/sidebar.md
+++ b/en/sidebar.md
@@ -8,7 +8,7 @@
     - [NFR](/[[language]]/[[version]]/new-feature-request)
     - [Backtrace Generation](/[[language]]/[[version]]/generating-backtrace)
     - [Reproducible Tests](/[[language]]/[[version]]/reproducible-tests)
-    - Testing guide
+    - [Testing guide](/[[language]]/[[version]]/unit-testing)
 - Getting Started
     - [Installation](/[[language]]/[[version]]/installation)
     - [Webserver Setup](/[[language]]/[[version]]/webserver-setup)


### PR DESCRIPTION
###### Fix link to testing guide

Closes https://github.com/phalcon/docs/issues/1238 

Added the link to `Testing guide` in the sidebar to link to the `unit-testing.md`