### PR TITLE
Remove code tags from side bar menu

### DIFF
--- a/en/unit-testing.md
+++ b/en/unit-testing.md
@@ -10,7 +10,7 @@
           <a href="#unit-helper">The PHPUnit helper file</a>
         </li>
         <li>
-          <a href="#phpunit-config">The <code>phpunit.xml</code> file</a>
+          <a href="#phpunit-config">The phpunit.xml file</a>
         </li>
         <li>
           <a href="#sample">Sample Unit Test</a>


### PR DESCRIPTION
closes https://github.com/phalcon/docs/issues/1295

Removed the `code` tags from the menu items in the side bar.