### PR TITLE
[WIP] Add document edit button to FAQ page for conversation

### DIFF
--- a/en/faq.md
+++ b/en/faq.md
@@ -34,3 +34,7 @@ credit: [https://github.com/andresgutierrez](https://github.com/andresgutierrez)
 ## How do I help?
 
 Join our [Discord](https://phalcon.link/discord) channel, visit us at [GitHub](https://github.com/phalcon), or on the web at [https://phalconphp.com/](https://phalconphp.com/en/).
+
+<a href="#" class="" style="position: fixed; bottom: 16px; right: 24px; z-index: 100;">
+  <img src="/images/edit_button.svg" alt="edit" style="height: 48px;">
+</a>


### PR DESCRIPTION
###### add document edit button to FAQ page for conversation

This is an edit button that @ninjapanzer and I discussed in the Discord room. I put it on the `FAQ` page for show and tell. It is fixed in that position to the page, so it does not move as the page scrolls.

Just a conversation piece, till we know the details or have a plan.

<img width="1054" alt="screen shot 2017-09-21 at 10 00 29 pm" src="https://user-images.githubusercontent.com/13909325/30726489-21edab4e-9f19-11e7-8afe-0cb3001c3077.png">

![edit_button](https://user-images.githubusercontent.com/13909325/30726545-7aa263ce-9f19-11e7-9421-1ab122311459.gif)


