### PR TITLE
Fix Issue #1369, Typo in page for Phalcon\Mvc\Model\Resultset\Simple

### DIFF
--- a/en/api/Phalcon_Mvc_Model_Resultset_Simple.md
+++ b/en/api/Phalcon_Mvc_Model_Resultset_Simple.md
@@ -80,8 +80,8 @@ Rewinds resultset to its beginning
 
 final public  **seek** (*mixed* $position) inherited from [Phalcon\Mvc\Model\Resultset](/en/3.2/api/Phalcon_Mvc_Model_Resultset)
 
-Changes internal pointer to a specific position in the resultset
-Set new position if required and set this->_row
+Changes the internal pointer to a specific position in the resultset. 
+Set the new position if required, and then set this->_row
 
 
 


### PR DESCRIPTION
###### Fix Issue #1369, Typo in page for Phalcon\Mvc\Model\Resultset\Simple

Closes issue #1369 

Fixed the missing period and adjusted the wording slightly.
_image attached_

<img width="763" alt="screen shot 2017-11-01 at 8 29 48 pm" src="https://user-images.githubusercontent.com/13909325/32304174-b7e39c2c-bf43-11e7-9824-0257da19982d.png">
