### PR TITLE
Added note for the notFound method

### DIFF
--- a/en/routing.md
+++ b/en/routing.md
@@ -785,6 +785,8 @@ $router->notFound(
 
 This is typically for an Error 404 page.
 
+> This will only work if the router was created without default routes: `$router = Phalcon\Mvc\Router(FALSE);`
+
 <a name='default-paths'></a>
 ## Setting default paths
 It's possible to define default values for the module, controller or action. When a route is missing any of those paths they can be automatically filled by the router:


### PR DESCRIPTION
Apparently the `notFound()` method only works if the router was created with `$defaultRoutes = false` as described here: https://stackoverflow.com/a/24739380/1016746
Maybe it's not intended, but right now this is how it works, so it is better to be noted in the docs.