### PR TITLE
Correct misspelled setContext function to setContent and rename variables to content

### DIFF
--- a/en/application-micro.md
+++ b/en/application-micro.md
@@ -351,8 +351,8 @@ Accessing the `$app` object inside the anonymous function can be achieved by inj
 $app->get(
     '/orders/display/{name}',
     function ($name) use ($app) {
-        $context = "<h1>This is order: {$name}!</h1>";
-        $app->response->setContext($context);
+        $content = "<h1>This is order: {$name}!</h1>";
+        $app->response->setContent($content);
         $app->response->send();
     }
 );
@@ -478,8 +478,8 @@ class OrdersController extends Controller
 
     public function show($name)
     {
-        $context = "<h1>This is order: {$name}!</h1>";
-        $this->response->setContext($context);
+        $content = "<h1>This is order: {$name}!</h1>";
+        $this->response->setContent($content);
 
         return $this->response;
     }


### PR DESCRIPTION
###### Closes #1483 

As pointed out in the issue `setContext` is undocumented and it appears that `setContent` is more appropriate here.
