### PR TITLE
Update devtools-usage.md - example is ini not php

### DIFF
--- a/en/devtools-usage.md
+++ b/en/devtools-usage.md
@@ -158,9 +158,9 @@ class TestController extends Controller
 
 <a name='database-settings'></a>
 ## Preparing Database Settings
-When a project is generated using developer tools. A configuration file can be found in `app/config/config.php`. To generate models or scaffold, you will need to change the settings used to connect to your database.
+When a project is generated using developer tools. A configuration file can be found in `app/config/config.ini`. To generate models or scaffold, you will need to change the settings used to connect to your database.
 
-Change the database section in your config.php file:
+Change the database section in your config.ini file:
 
 ```ini
 [database]


### PR DESCRIPTION
Code shown in https://github.com/phalcon/docs/blob/3.3/en/devtools-usage.md/#preparing-database-settings
is:

```
[database]
adapter  = Mysql
host     = "127.0.0.1"
username = "root"
password = "secret"
dbname   = "store_db"

[phalcon]
controllersDir = "../app/controllers/"
modelsDir      = "../app/models/"
viewsDir       = "../app/views/"
baseUri        = "/store/"
```

and labeled as config.php

Should be config.ini for the example given.