### PR TITLE
update macOS instructions

### DIFF
--- a/en/devtools-installation.md
+++ b/en/devtools-installation.md
@@ -90,8 +90,8 @@ cd phalcon-devtools/
 Create a symbolic link to the phalcon.php script:
 
 ```bash
-ln -s ~/phalcon-devtools/phalcon.php /usr/bin/phalcon
-chmod ugo+x /usr/bin/phalcon
+ln -s ~/phalcon-devtools/phalcon.php /usr/local/bin/phalcon
+chmod ugo+x /usr/local/bin/phalcon
 ```
 
 <a name='installation-windows'></a>

--- a/en/devtools-installation.md
+++ b/en/devtools-installation.md
@@ -87,11 +87,18 @@ cd phalcon-devtools/
 
 ![](/images/content/devtools-mac-2.png)
 
-Create a symbolic link to the phalcon.php script:
+Next, we'll create a symbolic link to the `phalcon.php` script. On El Capitan and newer versions of macOS:
 
 ```bash
 ln -s ~/phalcon-devtools/phalcon.php /usr/local/bin/phalcon
 chmod ugo+x /usr/local/bin/phalcon
+```
+
+if you are running an older version:
+
+```bash
+ln -s ~/phalcon-devtools/phalcon.php /usr/bin/phalcon
+chmod ugo+x /usr/bin/phalcon
 ```
 
 <a name='installation-windows'></a>


### PR DESCRIPTION
macOS users should use `/usr/local/bin` instead of `/usr/bin` because of **SIP** or "System Integrity Protection" introduced in El Capitan update, where even root users are not allowed to edit anything in `/usr` `/bin` `/sbin` `/System` folders with exception being mentioned `/usr/local/bin`