### PR TITLE
document AdapterInterface::addInherit() usage

### DIFF
--- a/en/acl.md
+++ b/en/acl.md
@@ -457,7 +457,9 @@ You can still add any custom parameters to function and pass associative array i
 
 <a name='roles-inheritance'></a>
 ## Roles Inheritance
-You can build complex role structures using the inheritance that `Phalcon\Acl\Role` provides. Roles can inherit from other roles, thus allowing access to supersets or subsets of resources. To use role inheritance, you need to pass the inherited role as the second parameter of the method call, when adding that role in the list.
+You can build complex role structures using the inheritance that `Phalcon\Acl\Role` provides. Roles can inherit from other roles, thus allowing access to supersets or subsets of resources. There are two ways to use role inheritance:
+
+1. You can pass the inherited role as the second parameter of the method call, when adding that role in the list.
 
 ```php
 <?php
@@ -478,6 +480,25 @@ $acl->addRole($roleGuests);
 // Add 'Administrators' role inheriting from 'Guests' its accesses
 $acl->addRole($roleAdmins, $roleGuests);
 ```
+
+2. You can setup the relationships after roles are added
+```php
+<?php
+
+use Phalcon\Acl\Role;
+
+// Create some roles
+$roleAdmins = new Role('Administrators', 'Super-User role');
+$roleGuests = new Role('Guests');
+
+// Add Roles to ACL
+$acl->addRole($roleGuests);
+$acl->addRole($roleAdmins);
+
+// Have 'Administrators' role inherit from 'Guests' its accesses
+$acl->addInherit($rollAdmins, $roleGuests);
+```
+
 
 <a name='serialization'></a>
 ## Serializing ACL lists


### PR DESCRIPTION
the `addInherit()` method is extremely useful.  To setup your inherits as you use `addRole` then the roles need to be added in a specific order.  This way we can iterate though and add all the roles, then iterate though and add all of the inherit's.  I was disappointed when I did not see this in the docs but thought I remembered using it in the past.  In looking at the source code I realized it was still there but undocumented for some reason.