### PR TITLE
Update reference

### DIFF
--- a/en/filter-sanitizing-data.md
+++ b/en/filter-sanitizing-data.md
@@ -9,7 +9,7 @@ category: 'filter'
 <hr/>
 
 ## Filtering data
-The [Phalcon\Filter\FilterLocator](api/Phalcon_Filter_FilterLocator) both filters and sanitizes data, depending on the sanitizers used. For instance the `trim` sanitizer will remove all leading and trailing whitespace, leaving the remaining input unchanged. The description of each sanitizer (mentioned above) can help you understand and use the sanitizers according to your needs.
+The [Phalcon\Filter\FilterLocator](api/Phalcon_Filter_FilterLocator) both filters and sanitizes data, depending on the sanitizers used. For instance the `trim` sanitizer will remove all leading and trailing whitespace, leaving the remaining input unchanged. The description of each sanitizer (see [Built-in Sanitizers](https://docs.phalconphp.com/4.0/en/filter-sanitizers)) can help you to understand and use the sanitizers according to your needs.
 
 ```php
 <?php


### PR DESCRIPTION
Since the page is now split, "mentioned above" must be replaced with a link to the referenced page.