### PR TITLE
update acl-operations-inherintance

### DIFF
--- a/en/acl-operations-inheritance.md
+++ b/en/acl-operations-inheritance.md
@@ -36,10 +36,10 @@ $acl->addRole($guest);
  * Add the `accounting` inheriting from `guest` 
  */
 $acl->addRole($accounting, $guest);
+
 /**
  * Add the `manager` inheriting from `accounting` 
  */
-
 $acl->addRole($manager, $accounting);
 ```
 


### PR DESCRIPTION
I just fix a `enter` in the code.

The next sentence is right? I mean the double "you need". 

> To use role inheritance, you need, you need to pass the inherited role as the second parameter of the method call, when adding that role in the list.