### PR TITLE
 View::setViewsDir() doesn't need a trailing separator

### DIFF
--- a/en/views.md
+++ b/en/views.md
@@ -849,7 +849,6 @@ $di->set(
     function () {
         $view = new View();
 
-        // A trailing directory separator is required
         $view->setViewsDir('../app/views/');
 
         // Set the engine
@@ -906,7 +905,6 @@ use Phalcon\Mvc\View;
 
 $view = new View();
 
-// A trailing directory separator is required
 $view->setViewsDir('../app/views/');
 
 // Passing variables to the views, these will be created as local variables

--- a/en/views.md
+++ b/en/views.md
@@ -961,7 +961,6 @@ use Phalcon\Mvc\View\Simple as SimpleView;
 
 $view = new SimpleView();
 
-// A trailing directory separator is required
 $view->setViewsDir('../app/views/');
 
 // Render a view and return its contents as a string


### PR DESCRIPTION
Please wait for https://github.com/phalcon/cphalcon/pull/13979 to be merged first.