### PR TITLE
Integrate blog's MVC upgrade guide

### DIFF
--- a/en/upgrade.md
+++ b/en/upgrade.md
@@ -421,6 +421,91 @@ $criteria->limit(10, null);
 
 <hr/>
 
+## MVC
+
+> Status: **changes required**
+>
+> Usage: [MVC Documentation](mvc)
+{: .alert .alert-info }
+
+### Mvc\Collection
+- Removed `Phalcon\Mvc\Collection::validationHasFailed`
+- Removed calling `Phalcon\Mvc\Collection::validate` with object of type `Phalcon\Mvc\Model\ValidatorInterface`
+
+### Mvc\Micro\Lazyloader
+- Removed `__call` in favor of `callMethod`
+
+### Mvc\Model
+- Removed `Phalcon\Model::reset`
+- Added `isRelationshipLoaded` to check if relationship is loaded
+
+### Mvc\Model\Criteria
+- Removed `addWhere`
+- Removed `order`
+- Removed `order` in favor of `orderBy`
+
+### Mvc\Model\CriteriaInterface
+- Added `distinct`, `leftJoin`, `innerJoin`, `rightJoin`, `groupBy`, `having`, `cache`, `getColumns`, `getGroupBy`, `getHaving`
+
+### Mvc\Model\Manager
+- `Load` no longer reuses already initialized models
+
+### Mvc\Model\ManagerInterface
+- Added `isVisibleModelProperty`, `keepSnapshots`, `isKeepingSnapshots`, `useDynamicUpdate`, `isUsingDynamicUpdate`, `addHasManyToMany`, `existsHasManyToMany`, `getRelationRecords`, `getHasManyToMany`, `registerNamespaceAlias`, `getNamespaceAlias`
+
+### Mvc\Model\MessageInterface
+- Added `setModel`, `getModel`, `setCode`, `getCode`
+
+### Mvc\Model\QueryInterface
+- Added `getSingleResult`, `setBindParams`, `getBindParams`, `setBindTypes`, `setSharedLock`, `getBindTypes`, `getSql`
+
+### Mvc\Model\Query\BuilderInterface
+- Added `offset`
+
+### Mvc\Model\Query\Builder
+- Added bind support. The Query Builder has the same methods as `Phalcon\Mvc\Model\Query`; `getBindParams`, `setBindParams`, `getBindTypes` and `setBindTypes`.
+- Changed `addFrom` to remove third parameter `$with`
+
+### Mvc\Model\Query\BuilderInterface
+- Added `distinct`, `getDistinct`, `forUpdate`, `offset`, `getOffset`
+
+### Mvc\Model\RelationInterface
+- Added `getParams`
+
+### Mvc\Model\ResultsetInterface
+- Added `setHydrateMode`, `getHydrateMode`, `getMessages`, `update`, `delete`, `filter`
+
+### Mvc\Model\Transaction\ManagerInterface
+- Added `setDbService`, `getDbService`, `setRollbackPendent`, `getRollbackPendent`
+
+### Mvc\Model\Validator*
+- Removed `Phalcon\Mvc\Model\Validator\*` in favor of `Phalcon\Validation\Validator\*`
+
+### Mvc\ModelInterface
+- Added `getModelsMetaData`
+
+### Mvc\RouterInterface
+- Added `attach`
+
+### Mvc\Router\RouteInterface
+- Added `convert` so that calling `add` will return an instance that has `convert` method
+
+### Mvc\Router\RouteInterface
+- Added response handler to `Phalcon\Mvc\Micro`, `Phalcon\Mvc\Micro::setResponseHandler`, to allow use of a custom response handler.
+    
+### Mvc\User
+- Removed `Phalcon\Mvc\User\Component` - replaced by `Phalcon\Plugin`
+
+### Mvc\View
+- Removed `getParams`
+
+
+<hr/>
+
+## Plugin
+- Added `Phalcon\Plugin` - replaces `Phalcon\Mvc\User\Component`
+
+
 ## Router
 You can add `CONNECT`, `PURGE`, `TRACE` routes to the Router Group. They function the same as they do in the normal Router:
 

--- a/en/upgrade.md
+++ b/en/upgrade.md
@@ -503,7 +503,7 @@ $criteria->limit(10, null);
 <hr/>
 
 ## Plugin
-- Added `Phalcon\Plugin` - replaces `Phalcon\Mvc\User\Component`
+- Added `Phalcon\Plugin` - replaces `Phalcon\Mvc\User\Component`, `Phalcon\Mvc\User\Plugin` and `Phalcon\Mvc\User\Module`
 
 
 ## Router


### PR DESCRIPTION
Insert all MVC changes detailed in https://docs.phalconphp.com/4.0/th-th/upgrade plus the replacement of `Phalcon\Mvc\User\Component` by `Phalcon\Plugin`