### PR TITLE
Update di.md: add type hint to getDi() function

### DIFF
--- a/en/di.md
+++ b/en/di.md
@@ -1009,7 +1009,7 @@ class MyClass implements InjectionAwareInterface
         $this->di = $di;
     }
 
-    public function getDi()
+    public function getDi(): DiInterface
     {
         return $this->di;
     }


### PR DESCRIPTION
When implementing the `InjectionAwareInterface` the type `DiInterface` must be added to the method `getDi()`. Otherwise, a fatal error will happen.