### PR TITLE
Rephrase HTTP methods

### DIFF
--- a/en/application-micro.md
+++ b/en/application-micro.md
@@ -306,7 +306,7 @@ Stops the middleware execution
 Defining routes in a [Phalcon\Mvc\Micro][mvc-micro] application is very easy. Routes are defined as follows:
 
 ```text
-   Application : (method/verb): (route url/regex, callable PHP function/handler)
+   Application : (http method): (route url/regex, callable PHP function/handler)
 ```
 
 ### Activation
@@ -374,7 +374,7 @@ $application = new Micro($container);
 $application->setService('router', $router, true);
 ```
 
-Setting up your routes using the [Phalcon\Mvc\Micro][mvc-micro] applications verb methods (`get`, `post`, etc.) is much easier than setting up a router object with relevant routes and then injecting it in the application. Each method has its advantages and disadvantages. It all depends on the design and needs of your application.
+Setting up your routes using the [Phalcon\Mvc\Micro][mvc-micro] applications http methods (`get`, `post`, etc.) is much easier than setting up a router object with relevant routes and then injecting it in the application. Each method has its advantages and disadvantages. It all depends on the design and needs of your application.
 
 ### Rewrite Rules
 In order for routes to work, your web server needs to be configured with specific instructions. Please refer to the [webserver setup](webserver-setup) document for more information.
@@ -746,7 +746,7 @@ $products
 Using this simple change in implementation, all handlers remain uninstantiated until requested by a caller. Therefore whenever a caller requests `/invoices/get/2`, our application will instantiate the `InvoicesController` and call the `get` method in it. Our application now uses less resources than before.
 
 #### Not found (404)
-Any route that has not been matched in our [Phalcon\Mvc\Micro][mvc-micro] application will cause it to try and execute the handler defined with the `notFound` method. Similar to other methods/verbs (`get`, `post` etc.), you can register a handler in the `notFound` method which can be any callable PHP function.
+Any route that has not been matched in our [Phalcon\Mvc\Micro][mvc-micro] application will cause it to try and execute the handler defined with the `notFound` method. Similar to other http methods (`get`, `post` etc.), you can register a handler in the `notFound` method which can be any callable PHP function.
 ```php
 <?php
 
@@ -766,7 +766,7 @@ $app->notFound(
 
 You can also handle routes that have not been matched (404) with Middleware discussed below.  
 
-### Methods - Verbs
+### HTTP methods
 The [Phalcon\Mvc\Micro][mvc-micro] application provides a set of methods to bind the HTTP method with the route it is intended to.
 
 **delete**
@@ -1156,7 +1156,7 @@ Finally, you can perform redirections in your middleware (if you are using it). 
 ### URLs
 Another feature of the routes is setting up named routes and generating URLs for those routes. 
 
-You will need to name your routes to take advantage of this feature. This can be achieved with the `setName()` method that is exposed from the methods/verbs in our application (`get`, `post`, etc.);
+You will need to name your routes to take advantage of this feature. This can be achieved with the `setName()` method that is exposed from the http methods in our application (`get`, `post`, etc.);
 
 ```php
 <?php


### PR DESCRIPTION
HTTP defines **methods** to indicate the desired action to be performed on the identified resource. Not verbs. Sometimes they are referred to as _verbs_, but nowhere in the specification does it mention _verb_, nor is OPTIONS or HEAD a _verb_. Even more, such exotic term in that context is hard to translate to other languages. I propose to replace _verb method_ by _http method_.