### PR TITLE
Serializer\SerializerFactory doesn't exist

### DIFF
--- a/en/db-models-cache.md
+++ b/en/db-models-cache.md
@@ -25,7 +25,7 @@ When [Phalcon\Mvc\Model][mvc-model] requires a service to cache resultsets, it w
 use Phalcon\Cache;
 use Phalcon\Cache\AdapterFactory;
 use Phalcon\Di\FactoryDefault;
-use Phalcon\Storage\Serializer\SerializerFactory;
+use Phalcon\Storage\SerializerFactory;
 
 $container = new FactoryDefault();
 


### PR DESCRIPTION
The class Phalcon\Storage\Serializer\SerializerFactory doesn't exist. I searched in phalcon/cphalcon and found this class : Phalcon\Storage\SerializerFactory. I've tried with it and it works. Maybe SerializerFactory isn't in the right folder in the cphalcon project ?