### PR TITLE
Phalcon\Mvc\User\Plugin and AbstractInjectionAware

### DIFF
--- a/en/upgrade.md
+++ b/en/upgrade.md
@@ -1182,9 +1182,9 @@ Phalcon\Assets\Resource\Js  | Renamed to | Phalcon\Assets\Asset\Js  |
 | Phalcon\Mvc\Model\Validator\Url              | Renamed to | Phalcon\Validation\Validator\Url          |
 | Phalcon\Mvc\Url                              | Renamed to | Phalcon\Url                               |
 | Phalcon\Mvc\Url\Exception                    | Renamed to | Phalcon\Url\Exception                     |
-| Phalcon\Mvc\User\Component                   | Renamed to | Phalcon\Di\AbstractInjectionAware         |
-| Phalcon\Mvc\User\Module                      | Renamed to | Phalcon\Di\AbstractInjectionAware         |
-| Phalcon\Mvc\User\Plugin                      | Renamed to | Phalcon\Di\AbstractInjectionAware         |
+| Phalcon\Mvc\User\Component                   | Renamed to | Phalcon\Di\Injectable                     |
+| Phalcon\Mvc\User\Module                      | Renamed to | Phalcon\Di\Injectable                     |
+| Phalcon\Mvc\User\Plugin                      | Renamed to | Phalcon\Di\Injectable                     |
 | Phalcon\Mvc\View\Engine                      | Renamed to | Phalcon\Mvc\View\Engine\AbstractEngine    |
 
 ### Paginator


### PR DESCRIPTION
I tried to rename \Phalcon\Mvc\User\Plugin with Phalcon\Di\AbstractInjectionAware and noticed an error. But when I used Phalcon\Di\Injectable, it worked. I also saw (in the middle of the documentation : lines 737-739) that Phalcon\Mvc\User\Component, Phalcon\Mvc\User\Module and \Phalcon\Mvc\User\Plugin were removed and it's OK to use Phalcon\Di\Injectable instead.