### PR TITLE
Wrong parameter name for Remove filter

### DIFF
--- a/en/filter.md
+++ b/en/filter.md
@@ -140,7 +140,7 @@ Performs a regex replacement on the input using a `pattern` and the `replace` pa
 
 #### `remove`
 ```php
-Remove( mixed $input, mixed $remove ): string
+Remove( mixed $input, mixed $replace ): string
 ```
 Performs a replacement on the input, replacing the `replace` parameter with an empty string, effectively removing it. Internally it uses [`str_replace`][str_replace].
 


### PR DESCRIPTION
Second parameter of Remove is `$replace` not `$remove`. I've checked it by reading this file : https://github.com/phalcon/cphalcon/blob/4.0.x/phalcon/Filter/Sanitize/Remove.zep