### PR TITLE
Remove Ondrej library

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -146,23 +146,6 @@ sudo apt-get update
 sudo apt-get install php7.2-phalcon
 ```
 
-##### Additional PPAs
-**Ondřej Surý**
-
-If you do not wish to use our repository at [packagecloud.io][packagecloud], you can always use the one offered by [Ondřej Surý][ondrej].
-
-Installation of the repo:
-```php
-sudo add-apt-repository ppa:ondrej/php
-sudo apt-get update
-```
-
-and Phalcon:
-
-```php
-sudo apt-get install php-phalcon
-```
-
 #### RPM Based Distributions (CentOS, Fedora, Etc.)
 
 ##### Repository installation


### PR DESCRIPTION
Looks like Ondrej isn't supporting 4.0 yet. https://launchpad.net/~ondrej/+archive/ubuntu/php/+packages?field.name_filter=phalcon&field.status_filter=published&field.series_filter=

Refs:
- https://github.com/phalcon/cphalcon/issues/14723
- https://github.com/oerdnj/deb.sury.org/issues/1307