### PR TITLE
Fix [Source on GitHub] links

### DIFF
--- a/en/api/phalcon_acl.md
+++ b/en/api/phalcon_acl.md
@@ -19,7 +19,7 @@ title: 'Phalcon\Acl'
         
 <h1 id="acl-adapter-abstractadapter">Abstract Class Phalcon\Acl\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Acl\Adapter |
 | Uses       | Phalcon\Events\ManagerInterface, Phalcon\Events\EventsAwareInterface |
@@ -119,7 +119,7 @@ Sets the events manager
         
 <h1 id="acl-adapter-adapterinterface">Interface Phalcon\Acl\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Acl\Adapter |
 | Uses       | Phalcon\Acl\ComponentInterface, Phalcon\Acl\RoleInterface |
@@ -255,7 +255,7 @@ accessKey
         
 <h1 id="acl-adapter-memory">Class Phalcon\Acl\Adapter\Memory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/adapter/memory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/Adapter/Memory.zep)
 
 | Namespace  | Phalcon\Acl\Adapter |
 | Uses       | Phalcon\Acl\Enum, Phalcon\Acl\Role, Phalcon\Acl\RoleInterface, Phalcon\Acl\Component, Phalcon\Acl\Exception, Phalcon\Events\Manager, Phalcon\Acl\RoleAware, Phalcon\Acl\ComponentAware, Phalcon\Acl\ComponentInterface, ReflectionFunction |
@@ -606,7 +606,7 @@ accessKey
         
 <h1 id="acl-component">Class Phalcon\Acl\Component</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/component.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/Component.zep)
 
 | Namespace  | Phalcon\Acl |
 | Implements | ComponentInterface |
@@ -658,7 +658,7 @@ public function getName(): string
         
 <h1 id="acl-componentaware">Interface Phalcon\Acl\ComponentAware</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/componentaware.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/ComponentAware.zep)
 
 | Namespace  | Phalcon\Acl |
 
@@ -676,7 +676,7 @@ Returns component name
         
 <h1 id="acl-componentinterface">Interface Phalcon\Acl\ComponentInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/componentinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/ComponentInterface.zep)
 
 | Namespace  | Phalcon\Acl |
 
@@ -706,7 +706,7 @@ Returns the component name
         
 <h1 id="acl-enum">Class Phalcon\Acl\Enum</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/enum.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/Enum.zep)
 
 | Namespace  | Phalcon\Acl |
 
@@ -722,7 +722,7 @@ const DENY = 0;
         
 <h1 id="acl-exception">Class Phalcon\Acl\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/Exception.zep)
 
 | Namespace  | Phalcon\Acl |
 | Extends    | \Phalcon\Exception |
@@ -733,7 +733,7 @@ Class for exceptions thrown by Phalcon\Acl
         
 <h1 id="acl-role">Class Phalcon\Acl\Role</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/role.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/Role.zep)
 
 | Namespace  | Phalcon\Acl |
 | Implements | RoleInterface |
@@ -785,7 +785,7 @@ public function getName(): string
         
 <h1 id="acl-roleaware">Interface Phalcon\Acl\RoleAware</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/roleaware.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/RoleAware.zep)
 
 | Namespace  | Phalcon\Acl |
 
@@ -803,7 +803,7 @@ Returns role name
         
 <h1 id="acl-roleinterface">Interface Phalcon\Acl\RoleInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/acl/roleinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Acl/RoleInterface.zep)
 
 | Namespace  | Phalcon\Acl |
 

--- a/en/api/phalcon_annotations.md
+++ b/en/api/phalcon_annotations.md
@@ -20,7 +20,7 @@ title: 'Phalcon\Annotations'
         
 <h1 id="annotations-adapter-abstractadapter">Abstract Class Phalcon\Annotations\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Annotations\Adapter |
 | Uses       | Phalcon\Annotations\Reader, Phalcon\Annotations\Exception, Phalcon\Annotations\Collection, Phalcon\Annotations\Reflection, Phalcon\Annotations\ReaderInterface |
@@ -90,7 +90,7 @@ Sets the annotations parser
         
 <h1 id="annotations-adapter-adapterinterface">Interface Phalcon\Annotations\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Annotations\Adapter |
 | Uses       | Phalcon\Annotations\Reflection, Phalcon\Annotations\Collection, Phalcon\Annotations\ReaderInterface |
@@ -145,7 +145,7 @@ Sets the annotations parser
         
 <h1 id="annotations-adapter-apcu">Class Phalcon\Annotations\Adapter\Apcu</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/adapter/apcu.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Adapter/Apcu.zep)
 
 | Namespace  | Phalcon\Annotations\Adapter |
 | Uses       | Phalcon\Annotations\Reflection |
@@ -197,7 +197,7 @@ Writes parsed annotations to APCu
         
 <h1 id="annotations-adapter-memory">Class Phalcon\Annotations\Adapter\Memory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/adapter/memory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Adapter/Memory.zep)
 
 | Namespace  | Phalcon\Annotations\Adapter |
 | Uses       | Phalcon\Annotations\Reflection |
@@ -233,7 +233,7 @@ Writes parsed annotations to memory
         
 <h1 id="annotations-adapter-stream">Class Phalcon\Annotations\Adapter\Stream</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/adapter/stream.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Adapter/Stream.zep)
 
 | Namespace  | Phalcon\Annotations\Adapter |
 | Uses       | Phalcon\Annotations\Reflection, Phalcon\Annotations\Exception, RuntimeException |
@@ -284,7 +284,7 @@ Writes parsed annotations to files
         
 <h1 id="annotations-annotation">Class Phalcon\Annotations\Annotation</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/annotation.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Annotation.zep)
 
 | Namespace  | Phalcon\Annotations |
 
@@ -381,7 +381,7 @@ Returns the number of arguments that the annotation has
         
 <h1 id="annotations-annotationsfactory">Class Phalcon\Annotations\AnnotationsFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/annotationsfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/AnnotationsFactory.zep)
 
 | Namespace  | Phalcon\Annotations |
 | Uses       | Phalcon\Annotations\Adapter\AdapterInterface, Phalcon\Factory\AbstractFactory, Phalcon\Helper\Arr |
@@ -400,7 +400,7 @@ AdapterFactory constructor.
 ```php
 public function load( mixed $config ): mixed;
 ```
-Factory to create an instace from a Config object
+Factory to create an instance from a Config object
 
 
 ```php
@@ -419,7 +419,7 @@ The available adapters
         
 <h1 id="annotations-collection">Class Phalcon\Annotations\Collection</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/collection.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Collection.zep)
 
 | Namespace  | Phalcon\Annotations |
 | Uses       | Countable, Iterator |
@@ -527,7 +527,7 @@ Check if the current annotation in the iterator is valid
         
 <h1 id="annotations-exception">Class Phalcon\Annotations\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Exception.zep)
 
 | Namespace  | Phalcon\Annotations |
 | Extends    | \Phalcon\Exception |
@@ -538,7 +538,7 @@ Class for exceptions thrown by Phalcon\Annotations
         
 <h1 id="annotations-reader">Class Phalcon\Annotations\Reader</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/reader.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Reader.zep)
 
 | Namespace  | Phalcon\Annotations |
 | Uses       | ReflectionClass |
@@ -564,7 +564,7 @@ Parses a raw doc block returning the annotations found
         
 <h1 id="annotations-readerinterface">Interface Phalcon\Annotations\ReaderInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/readerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/ReaderInterface.zep)
 
 | Namespace  | Phalcon\Annotations |
 
@@ -588,7 +588,7 @@ Parses a raw docblock returning the annotations found
         
 <h1 id="annotations-reflection">Class Phalcon\Annotations\Reflection</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/annotations/reflection.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Annotations/Reflection.zep)
 
 | Namespace  | Phalcon\Annotations |
 

--- a/en/api/phalcon_application.md
+++ b/en/api/phalcon_application.md
@@ -10,7 +10,7 @@ title: 'Phalcon\Application'
         
 <h1 id="application-abstractapplication">Abstract Class Phalcon\Application\AbstractApplication</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/application/abstractapplication.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Application/AbstractApplication.zep)
 
 | Namespace  | Phalcon\Application |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\Injectable, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface |
@@ -112,7 +112,7 @@ Sets the events manager
         
 <h1 id="application-exception">Class Phalcon\Application\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/application/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Application/Exception.zep)
 
 | Namespace  | Phalcon\Application |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_assets.md
+++ b/en/api/phalcon_assets.md
@@ -22,7 +22,7 @@ title: 'Phalcon\Assets'
         
 <h1 id="assets-asset">Class Phalcon\Assets\Asset</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/asset.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Asset.zep)
 
 | Namespace  | Phalcon\Assets |
 | Implements | AssetInterface |
@@ -240,7 +240,7 @@ public function setVersion( 	string $version )
         
 <h1 id="assets-asset-css">Class Phalcon\Assets\Asset\Css</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/asset/css.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Asset/Css.zep)
 
 | Namespace  | Phalcon\Assets\Asset |
 | Uses       | Phalcon\Assets\Asset |
@@ -260,7 +260,7 @@ Phalcon\Assets\Asset\Css constructor
         
 <h1 id="assets-asset-js">Class Phalcon\Assets\Asset\Js</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/asset/js.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Asset/Js.zep)
 
 | Namespace  | Phalcon\Assets\Asset |
 | Uses       | Phalcon\Assets\Asset |
@@ -280,11 +280,11 @@ Phalcon\Assets\Asset\Js constructor
         
 <h1 id="assets-assetinterface">Interface Phalcon\Assets\AssetInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/assetinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/AssetInterface.zep)
 
 | Namespace  | Phalcon\Assets |
 
-Interface for custom Phalcon\Assets reources
+Interface for custom Phalcon\Assets resources
 
 
 ## Methods
@@ -334,7 +334,7 @@ Sets the asset's type.
         
 <h1 id="assets-collection">Class Phalcon\Assets\Collection</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/collection.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Collection.zep)
 
 | Namespace  | Phalcon\Assets |
 | Uses       | Countable, Iterator, Phalcon\Assets\Asset\Css, Phalcon\Assets\Asset\Js, Phalcon\Assets\Inline\Js, Phalcon\Assets\Inline\Css |
@@ -681,7 +681,7 @@ Adds a asset or inline-code to the collection
         
 <h1 id="assets-exception">Class Phalcon\Assets\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Exception.zep)
 
 | Namespace  | Phalcon\Assets |
 | Extends    | \Phalcon\Exception |
@@ -692,7 +692,7 @@ Exceptions thrown in Phalcon\Assets will use this class
         
 <h1 id="assets-filterinterface">Interface Phalcon\Assets\FilterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/filterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/FilterInterface.zep)
 
 | Namespace  | Phalcon\Assets |
 
@@ -710,7 +710,7 @@ Filters the content returning a string with the filtered content
         
 <h1 id="assets-filters-cssmin">Class Phalcon\Assets\Filters\Cssmin</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/filters/cssmin.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Filters/Cssmin.zep)
 
 | Namespace  | Phalcon\Assets\Filters |
 | Uses       | Phalcon\Assets\FilterInterface |
@@ -732,7 +732,7 @@ NOTE: This functionality is not currently available
         
 <h1 id="assets-filters-jsmin">Class Phalcon\Assets\Filters\Jsmin</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/filters/jsmin.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Filters/Jsmin.zep)
 
 | Namespace  | Phalcon\Assets\Filters |
 | Uses       | Phalcon\Assets\FilterInterface |
@@ -755,7 +755,7 @@ NOTE: This functionality is not currently available
         
 <h1 id="assets-filters-none">Class Phalcon\Assets\Filters\None</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/filters/none.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Filters/None.zep)
 
 | Namespace  | Phalcon\Assets\Filters |
 | Uses       | Phalcon\Assets\FilterInterface |
@@ -775,7 +775,7 @@ Returns the content as is
         
 <h1 id="assets-inline">Class Phalcon\Assets\Inline</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/inline.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Inline.zep)
 
 | Namespace  | Phalcon\Assets |
 | Implements | AssetInterface |
@@ -866,7 +866,7 @@ Sets the inline's type
         
 <h1 id="assets-inline-css">Class Phalcon\Assets\Inline\Css</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/inline/css.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Inline/Css.zep)
 
 | Namespace  | Phalcon\Assets\Inline |
 | Uses       | Phalcon\Assets\Inline |
@@ -886,7 +886,7 @@ Phalcon\Assets\Inline\Css constructor
         
 <h1 id="assets-inline-js">Class Phalcon\Assets\Inline\Js</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/inline/js.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Inline/Js.zep)
 
 | Namespace  | Phalcon\Assets\Inline |
 | Uses       | Phalcon\Assets\Inline |
@@ -906,7 +906,7 @@ Phalcon\Assets\Inline\Js constructor
         
 <h1 id="assets-manager">Class Phalcon\Assets\Manager</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/assets/manager.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Assets/Manager.zep)
 
 | Namespace  | Phalcon\Assets |
 | Uses       | Phalcon\Tag, Phalcon\Assets\Asset\Js, Phalcon\Assets\Asset\Css, Phalcon\Assets\Inline\Css, Phalcon\Assets\Inline\Js, Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware |

--- a/en/api/phalcon_cache.md
+++ b/en/api/phalcon_cache.md
@@ -19,7 +19,7 @@ title: 'Phalcon\Cache'
         
 <h1 id="cache">Class Phalcon\Cache</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Cache\Exception\Exception, Phalcon\Cache\Exception\InvalidArgumentException, Psr\SimpleCache\CacheInterface, Traversable |
@@ -158,7 +158,7 @@ Checks the key. If it contains invalid characters an exception is thrown
         
 <h1 id="cache-adapter-adapterinterface">Interface Phalcon\Cache\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Cache\Adapter |
 | Uses       | Phalcon\Storage\Adapter\AdapterInterface |
@@ -170,7 +170,7 @@ Interface for Phalcon\Cache adapters
         
 <h1 id="cache-adapter-apcu">Class Phalcon\Cache\Adapter\Apcu</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/adapter/apcu.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Adapter/Apcu.zep)
 
 | Namespace  | Phalcon\Cache\Adapter |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Storage\Adapter\Apcu |
@@ -183,7 +183,7 @@ Apcu adapter
         
 <h1 id="cache-adapter-libmemcached">Class Phalcon\Cache\Adapter\Libmemcached</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/adapter/libmemcached.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Adapter/Libmemcached.zep)
 
 | Namespace  | Phalcon\Cache\Adapter |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Storage\Adapter\Libmemcached |
@@ -196,7 +196,7 @@ Libmemcached adapter
         
 <h1 id="cache-adapter-memory">Class Phalcon\Cache\Adapter\Memory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/adapter/memory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Adapter/Memory.zep)
 
 | Namespace  | Phalcon\Cache\Adapter |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Storage\Adapter\Memory |
@@ -209,7 +209,7 @@ Memory adapter
         
 <h1 id="cache-adapter-redis">Class Phalcon\Cache\Adapter\Redis</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/adapter/redis.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Adapter/Redis.zep)
 
 | Namespace  | Phalcon\Cache\Adapter |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Storage\Adapter\Redis |
@@ -222,7 +222,7 @@ Redis adapter
         
 <h1 id="cache-adapter-stream">Class Phalcon\Cache\Adapter\Stream</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/adapter/stream.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Adapter/Stream.zep)
 
 | Namespace  | Phalcon\Cache\Adapter |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Storage\Adapter\Stream |
@@ -235,7 +235,7 @@ Stream adapter
         
 <h1 id="cache-adapterfactory">Class Phalcon\Cache\AdapterFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/adapterfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/AdapterFactory.zep)
 
 | Namespace  | Phalcon\Cache |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Cache\Exception\Exception, Phalcon\Factory\AbstractFactory, Phalcon\Storage\SerializerFactory |
@@ -276,7 +276,7 @@ Returns the available adapters
         
 <h1 id="cache-cachefactory">Class Phalcon\Cache\CacheFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/cachefactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/CacheFactory.zep)
 
 | Namespace  | Phalcon\Cache |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Cache, Psr\SimpleCache\CacheInterface, Phalcon\Cache\Exception\Exception, Phalcon\Config, Phalcon\Helper\Arr |
@@ -303,7 +303,7 @@ Constructor
 ```php
 public function load( mixed $config ): mixed;
 ```
-Factory to create an instace from a Config object
+Factory to create an instance from a Config object
 
 
 ```php
@@ -316,7 +316,7 @@ Constructs a new Cache instance.
         
 <h1 id="cache-exception-exception">Class Phalcon\Cache\Exception\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/exception/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Exception/Exception.zep)
 
 | Namespace  | Phalcon\Cache\Exception |
 | Extends    | \Phalcon\Exception |
@@ -328,7 +328,7 @@ Exceptions thrown in Phalcon\Cache will use this class
         
 <h1 id="cache-exception-invalidargumentexception">Class Phalcon\Cache\Exception\InvalidArgumentException</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cache/exception/invalidargumentexception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cache/Exception/InvalidArgumentException.zep)
 
 | Namespace  | Phalcon\Cache\Exception |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_cli.md
+++ b/en/api/phalcon_cli.md
@@ -20,7 +20,7 @@ title: 'Phalcon\Cli'
         
 <h1 id="cli-console">Class Phalcon\Cli\Console</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/console.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Console.zep)
 
 | Namespace  | Phalcon\Cli |
 | Uses       | Phalcon\Application\AbstractApplication, Phalcon\Cli\Router\Route, Phalcon\Cli\Console\Exception, Phalcon\Di\DiInterface, Phalcon\Events\ManagerInterface |
@@ -60,7 +60,7 @@ Set an specific argument
         
 <h1 id="cli-console-exception">Class Phalcon\Cli\Console\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/console/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Console/Exception.zep)
 
 | Namespace  | Phalcon\Cli\Console |
 | Extends    | \Phalcon\Application\Exception |
@@ -71,7 +71,7 @@ Exceptions thrown in Phalcon\Cli\Console will use this class
         
 <h1 id="cli-dispatcher">Class Phalcon\Cli\Dispatcher</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/dispatcher.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Dispatcher.zep)
 
 | Namespace  | Phalcon\Cli |
 | Uses       | Phalcon\Cli\Dispatcher\Exception, Phalcon\Dispatcher\AbstractDispatcher, Phalcon\Events\ManagerInterface, Phalcon\Filter\FilterInterface |
@@ -214,7 +214,7 @@ Throws an internal exception
         
 <h1 id="cli-dispatcher-exception">Class Phalcon\Cli\Dispatcher\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/dispatcher/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Dispatcher/Exception.zep)
 
 | Namespace  | Phalcon\Cli\Dispatcher |
 | Extends    | \Phalcon\Dispatcher\Exception |
@@ -225,7 +225,7 @@ Exceptions thrown in Phalcon\Cli\Dispatcher will use this class
         
 <h1 id="cli-dispatcherinterface">Interface Phalcon\Cli\DispatcherInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/dispatcherinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/DispatcherInterface.zep)
 
 | Namespace  | Phalcon\Cli |
 | Uses       | Phalcon\Dispatcher\DispatcherInterface |
@@ -293,7 +293,7 @@ Sets the default task suffix
         
 <h1 id="cli-router">Class Phalcon\Cli\Router</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/router.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Router.zep)
 
 | Namespace  | Phalcon\Cli |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Cli\Router\Route, Phalcon\Cli\Router\Exception, Phalcon\Cli\Router\RouteInterface |
@@ -488,7 +488,7 @@ Checks if the router matches any of the defined routes
         
 <h1 id="cli-router-exception">Class Phalcon\Cli\Router\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/router/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Router/Exception.zep)
 
 | Namespace  | Phalcon\Cli\Router |
 | Extends    | \Phalcon\Exception |
@@ -499,7 +499,7 @@ Exceptions thrown in Phalcon\Cli\Router will use this class
         
 <h1 id="cli-router-route">Class Phalcon\Cli\Router\Route</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/router/route.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Router/Route.zep)
 
 | Namespace  | Phalcon\Cli\Router |
 | Implements | RouteInterface |
@@ -689,7 +689,7 @@ $router->add(
         
 <h1 id="cli-router-routeinterface">Interface Phalcon\Cli\Router\RouteInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/router/routeinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Router/RouteInterface.zep)
 
 | Namespace  | Phalcon\Cli\Router |
 
@@ -786,7 +786,7 @@ Sets the route's name
         
 <h1 id="cli-routerinterface">Interface Phalcon\Cli\RouterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/routerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/RouterInterface.zep)
 
 | Namespace  | Phalcon\Cli |
 | Uses       | Phalcon\Cli\Router\RouteInterface |
@@ -896,7 +896,7 @@ Check if the router matches any of the defined routes
         
 <h1 id="cli-task">Class Phalcon\Cli\Task</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/task.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/Task.zep)
 
 | Namespace  | Phalcon\Cli |
 | Uses       | Phalcon\Di\Injectable, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface |
@@ -957,7 +957,7 @@ Sets the events manager
         
 <h1 id="cli-taskinterface">Interface Phalcon\Cli\TaskInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/cli/taskinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Cli/TaskInterface.zep)
 
 | Namespace  | Phalcon\Cli |
 

--- a/en/api/phalcon_collection.md
+++ b/en/api/phalcon_collection.md
@@ -11,7 +11,7 @@ title: 'Phalcon\Collection'
         
 <h1 id="collection">Class Phalcon\Collection</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/collection.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Collection.zep)
 
 | Namespace  | Phalcon |
 | Uses       | ArrayAccess, ArrayIterator, Countable, IteratorAggregate, JsonSerializable, Phalcon\Helper\Json, Serializable, Traversable |
@@ -216,7 +216,7 @@ Internal method to set data
         
 <h1 id="collection-exception">Class Phalcon\Collection\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/collection/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Collection/Exception.zep)
 
 | Namespace  | Phalcon\Collection |
 | Uses       | Throwable |
@@ -229,7 +229,7 @@ Exceptions for the Collection object
         
 <h1 id="collection-readonly">Class Phalcon\Collection\ReadOnly</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/collection/readonly.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Collection/ReadOnly.zep)
 
 | Namespace  | Phalcon\Collection |
 | Uses       | Phalcon\Collection |

--- a/en/api/phalcon_config.md
+++ b/en/api/phalcon_config.md
@@ -16,7 +16,7 @@ title: 'Phalcon\Config'
         
 <h1 id="config">Class Phalcon\Config</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Collection, Phalcon\Config\Exception |
@@ -132,7 +132,7 @@ Sets the collection data
         
 <h1 id="config-adapter-grouped">Class Phalcon\Config\Adapter\Grouped</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config/adapter/grouped.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config/Adapter/Grouped.zep)
 
 | Namespace  | Phalcon\Config\Adapter |
 | Uses       | Phalcon\Config, Phalcon\Config\Exception, Phalcon\Factory\Exception, Phalcon\Config\ConfigFactory |
@@ -200,7 +200,7 @@ Phalcon\Config\Adapter\Grouped constructor
         
 <h1 id="config-adapter-ini">Class Phalcon\Config\Adapter\Ini</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config/adapter/ini.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config/Adapter/Ini.zep)
 
 | Namespace  | Phalcon\Config\Adapter |
 | Uses       | Phalcon\Config, Phalcon\Config\Exception |
@@ -272,7 +272,7 @@ Build multidimensional array from string
         
 <h1 id="config-adapter-json">Class Phalcon\Config\Adapter\Json</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config/adapter/json.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config/Adapter/Json.zep)
 
 | Namespace  | Phalcon\Config\Adapter |
 | Uses       | Phalcon\Config, Phalcon\Helper\Json |
@@ -309,7 +309,7 @@ Phalcon\Config\Adapter\Json constructor
         
 <h1 id="config-adapter-php">Class Phalcon\Config\Adapter\Php</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config/adapter/php.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config/Adapter/Php.zep)
 
 | Namespace  | Phalcon\Config\Adapter |
 | Uses       | Phalcon\Config |
@@ -361,7 +361,7 @@ Phalcon\Config\Adapter\Php constructor
         
 <h1 id="config-adapter-yaml">Class Phalcon\Config\Adapter\Yaml</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config/adapter/yaml.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config/Adapter/Yaml.zep)
 
 | Namespace  | Phalcon\Config\Adapter |
 | Uses       | Phalcon\Config, Phalcon\Config\Exception |
@@ -415,7 +415,7 @@ Phalcon\Config\Adapter\Yaml constructor
         
 <h1 id="config-configfactory">Class Phalcon\Config\ConfigFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config/configfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config/ConfigFactory.zep)
 
 | Namespace  | Phalcon\Config |
 | Uses       | Phalcon\Config, Phalcon\Config\Adapter\Grouped, Phalcon\Config\Adapter\Ini, Phalcon\Config\Adapter\Json, Phalcon\Config\Adapter\Php, Phalcon\Config\Adapter\Yaml, Phalcon\Factory\AbstractFactory, Phalcon\Factory\Exception, Phalcon\Helper\Arr |
@@ -465,7 +465,7 @@ Returns the adapters for the factory
         
 <h1 id="config-exception">Class Phalcon\Config\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/config/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Config/Exception.zep)
 
 | Namespace  | Phalcon\Config |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_container.md
+++ b/en/api/phalcon_container.md
@@ -9,7 +9,7 @@ title: 'Phalcon\Container'
         
 <h1 id="container">Class Phalcon\Container</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/container.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Container.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Psr\Container\ContainerInterface, Phalcon\Di\DiInterface |

--- a/en/api/phalcon_crypt.md
+++ b/en/api/phalcon_crypt.md
@@ -12,7 +12,7 @@ title: 'Phalcon\Crypt'
         
 <h1 id="crypt">Class Phalcon\Crypt</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/crypt.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Crypt.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Crypt\CryptInterface, Phalcon\Crypt\Exception, Phalcon\Crypt\Mismatch |
@@ -306,7 +306,7 @@ Initialize available cipher algorithms.
         
 <h1 id="crypt-cryptinterface">Interface Phalcon\Crypt\CryptInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/crypt/cryptinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Crypt/CryptInterface.zep)
 
 | Namespace  | Phalcon\Crypt |
 
@@ -414,7 +414,7 @@ Changes the padding scheme used.
         
 <h1 id="crypt-exception">Class Phalcon\Crypt\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/crypt/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Crypt/Exception.zep)
 
 | Namespace  | Phalcon\Crypt |
 | Extends    | \Phalcon\Exception |
@@ -425,7 +425,7 @@ Exceptions thrown in Phalcon\Crypt use this class
         
 <h1 id="crypt-mismatch">Class Phalcon\Crypt\Mismatch</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/crypt/mismatch.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Crypt/Mismatch.zep)
 
 | Namespace  | Phalcon\Crypt |
 | Extends    | Exception |

--- a/en/api/phalcon_db.md
+++ b/en/api/phalcon_db.md
@@ -34,7 +34,7 @@ title: 'Phalcon\Db'
         
 <h1 id="db-abstractdb">Abstract Class Phalcon\Db\AbstractDb</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/abstractdb.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/AbstractDb.zep)
 
 | Namespace  | Phalcon\Db |
 | Uses       | \PDO |
@@ -93,7 +93,7 @@ Enables/disables options in the Database component
         
 <h1 id="db-adapter-abstractadapter">Abstract Class Phalcon\Db\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Db\Adapter |
 | Uses       | Phalcon\Db\DialectInterface, Phalcon\Db\ColumnInterface, Phalcon\Db\Enum, Phalcon\Db\Exception, Phalcon\Db\Index, Phalcon\Db\IndexInterface, Phalcon\Db\Reference, Phalcon\Db\ReferenceInterface, Phalcon\Db\RawValue, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface |
@@ -751,7 +751,7 @@ var_dump(
         
 <h1 id="db-adapter-adapterinterface">Interface Phalcon\Db\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Db\Adapter |
 | Uses       | Phalcon\Db\DialectInterface, Phalcon\Db\ResultInterface, Phalcon\Db\ColumnInterface, Phalcon\Db\IndexInterface, Phalcon\Db\RawValue, Phalcon\Db\ReferenceInterface |
@@ -1206,7 +1206,7 @@ Generates SQL checking for the existence of a schema.view
         
 <h1 id="db-adapter-pdo-abstractpdo">Abstract Class Phalcon\Db\Adapter\Pdo\AbstractPdo</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/adapter/pdo/abstractpdo.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Adapter/Pdo/AbstractPdo.zep)
 
 | Namespace  | Phalcon\Db\Adapter\Pdo |
 | Uses       | Phalcon\Db\Adapter\AbstractAdapter, Phalcon\Db\Column, Phalcon\Db\Exception, Phalcon\Db\Result\Pdo, Phalcon\Db\ResultInterface, Phalcon\Events\ManagerInterface |
@@ -1510,7 +1510,7 @@ Returns PDO adapter DSN defaults as a key-value map.
         
 <h1 id="db-adapter-pdo-mysql">Class Phalcon\Db\Adapter\Pdo\Mysql</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/adapter/pdo/mysql.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Adapter/Pdo/Mysql.zep)
 
 | Namespace  | Phalcon\Db\Adapter\Pdo |
 | Uses       | Phalcon\Db\Adapter\Pdo\AbstractPdo, Phalcon\Db\Column, Phalcon\Db\ColumnInterface, Phalcon\Db\Enum, Phalcon\Db\Exception, Phalcon\Db\Index, Phalcon\Db\IndexInterface, Phalcon\Db\Reference, Phalcon\Db\ReferenceInterface |
@@ -1600,7 +1600,7 @@ Returns PDO adapter DSN defaults as a key-value map.
         
 <h1 id="db-adapter-pdo-postgresql">Class Phalcon\Db\Adapter\Pdo\Postgresql</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/adapter/pdo/postgresql.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Adapter/Pdo/Postgresql.zep)
 
 | Namespace  | Phalcon\Db\Adapter\Pdo |
 | Uses       | Phalcon\Db\Adapter\Pdo\AbstractPdo, Phalcon\Db\Column, Phalcon\Db\ColumnInterface, Phalcon\Db\Enum, Phalcon\Db\Exception, Phalcon\Db\RawValue, Phalcon\Db\Reference, Phalcon\Db\ReferenceInterface, Throwable |
@@ -1734,7 +1734,7 @@ Returns PDO adapter DSN defaults as a key-value map.
         
 <h1 id="db-adapter-pdo-sqlite">Class Phalcon\Db\Adapter\Pdo\Sqlite</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/adapter/pdo/sqlite.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Adapter/Pdo/Sqlite.zep)
 
 | Namespace  | Phalcon\Db\Adapter\Pdo |
 | Uses       | Phalcon\Db\Adapter\Pdo\AbstractPdo, Phalcon\Db\Column, Phalcon\Db\ColumnInterface, Phalcon\Db\Enum, Phalcon\Db\Exception, Phalcon\Db\Index, Phalcon\Db\IndexInterface, Phalcon\Db\RawValue, Phalcon\Db\Reference, Phalcon\Db\ReferenceInterface |
@@ -1850,7 +1850,7 @@ Returns PDO adapter DSN defaults as a key-value map.
         
 <h1 id="db-adapter-pdofactory">Class Phalcon\Db\Adapter\PdoFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/adapter/pdofactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Adapter/PdoFactory.zep)
 
 | Namespace  | Phalcon\Db\Adapter |
 | Uses       | Phalcon\Factory\AbstractFactory, Phalcon\Helper\Arr |
@@ -1893,7 +1893,7 @@ Returns the available adapters
         
 <h1 id="db-column">Class Phalcon\Db\Column</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/column.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Column.zep)
 
 | Namespace  | Phalcon\Db |
 | Implements | ColumnInterface |
@@ -2160,7 +2160,7 @@ Returns true if number column is unsigned
         
 <h1 id="db-columninterface">Interface Phalcon\Db\ColumnInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/columninterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/ColumnInterface.zep)
 
 | Namespace  | Phalcon\Db |
 
@@ -2268,7 +2268,7 @@ Returns true if number column is unsigned
         
 <h1 id="db-dialect">Abstract Class Phalcon\Db\Dialect</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/dialect.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Dialect.zep)
 
 | Namespace  | Phalcon\Db |
 | Implements | DialectInterface |
@@ -2568,7 +2568,7 @@ Prepares table for this RDBMS
         
 <h1 id="db-dialect-mysql">Class Phalcon\Db\Dialect\Mysql</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/dialect/mysql.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Dialect/Mysql.zep)
 
 | Namespace  | Phalcon\Db\Dialect |
 | Uses       | Phalcon\Db\Dialect, Phalcon\Db\Column, Phalcon\Db\Exception, Phalcon\Db\IndexInterface, Phalcon\Db\ColumnInterface, Phalcon\Db\ReferenceInterface, Phalcon\Db\DialectInterface |
@@ -2771,7 +2771,7 @@ Generates SQL to add the table creation options
         
 <h1 id="db-dialect-postgresql">Class Phalcon\Db\Dialect\Postgresql</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/dialect/postgresql.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Dialect/Postgresql.zep)
 
 | Namespace  | Phalcon\Db\Dialect |
 | Uses       | Phalcon\Db\Dialect, Phalcon\Db\Column, Phalcon\Db\Exception, Phalcon\Db\IndexInterface, Phalcon\Db\ColumnInterface, Phalcon\Db\ReferenceInterface, Phalcon\Db\DialectInterface |
@@ -2967,7 +2967,7 @@ protected function getTableOptions( array $definition ): string;
         
 <h1 id="db-dialect-sqlite">Class Phalcon\Db\Dialect\Sqlite</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/dialect/sqlite.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Dialect/Sqlite.zep)
 
 | Namespace  | Phalcon\Db\Dialect |
 | Uses       | Phalcon\Db\Column, Phalcon\Db\Exception, Phalcon\Db\IndexInterface, Phalcon\Db\Dialect, Phalcon\Db\DialectInterface, Phalcon\Db\ColumnInterface, Phalcon\Db\ReferenceInterface |
@@ -3178,7 +3178,7 @@ Generates SQL checking for the existence of a schema.view
         
 <h1 id="db-dialectinterface">Interface Phalcon\Db\DialectInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/dialectinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/DialectInterface.zep)
 
 | Namespace  | Phalcon\Db |
 
@@ -3395,7 +3395,7 @@ Generates SQL checking for the existence of a schema.view
         
 <h1 id="db-enum">Class Phalcon\Db\Enum</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/enum.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Enum.zep)
 
 | Namespace  | Phalcon\Db |
 
@@ -3426,7 +3426,7 @@ const FETCH_UNIQUE;
         
 <h1 id="db-exception">Class Phalcon\Db\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Exception.zep)
 
 | Namespace  | Phalcon\Db |
 | Extends    | \Phalcon\Exception |
@@ -3437,7 +3437,7 @@ Exceptions thrown in Phalcon\Db will use this class
         
 <h1 id="db-index">Class Phalcon\Db\Index</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/index.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Index.zep)
 
 | Namespace  | Phalcon\Db |
 | Implements | IndexInterface |
@@ -3522,7 +3522,7 @@ public function getType(): string
         
 <h1 id="db-indexinterface">Interface Phalcon\Db\IndexInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/indexinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/IndexInterface.zep)
 
 | Namespace  | Phalcon\Db |
 
@@ -3552,7 +3552,7 @@ Gets the index type
         
 <h1 id="db-profiler">Class Phalcon\Db\Profiler</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/profiler.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Profiler.zep)
 
 | Namespace  | Phalcon\Db |
 | Uses       | Phalcon\Db\Profiler\Item |
@@ -3680,7 +3680,7 @@ Stops the active profile
         
 <h1 id="db-profiler-item">Class Phalcon\Db\Profiler\Item</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/profiler/item.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Profiler/Item.zep)
 
 | Namespace  | Phalcon\Db\Profiler |
 
@@ -3787,7 +3787,7 @@ public function setSqlVariables( array $sqlVariables )
         
 <h1 id="db-rawvalue">Class Phalcon\Db\RawValue</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/rawvalue.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/RawValue.zep)
 
 | Namespace  | Phalcon\Db |
 
@@ -3837,7 +3837,7 @@ public function getValue(): string
         
 <h1 id="db-reference">Class Phalcon\Db\Reference</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/reference.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Reference.zep)
 
 | Namespace  | Phalcon\Db |
 | Implements | ReferenceInterface |
@@ -3974,7 +3974,7 @@ public function getSchemaName(): string
         
 <h1 id="db-referenceinterface">Interface Phalcon\Db\ReferenceInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/referenceinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/ReferenceInterface.zep)
 
 | Namespace  | Phalcon\Db |
 
@@ -4034,7 +4034,7 @@ Gets the schema where referenced table is
         
 <h1 id="db-result-pdo">Class Phalcon\Db\Result\Pdo</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/result/pdo.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/Result/Pdo.zep)
 
 | Namespace  | Phalcon\Db\Result |
 | Uses       | Phalcon\Db\Enum, Phalcon\Db\ResultInterface, Phalcon\Db\Adapter\AdapterInterface |
@@ -4120,7 +4120,7 @@ public function execute(): bool;
 ```
 Allows to execute the statement again. Some database systems don't
 support scrollable cursors. So, as cursors are forward only, we need to
-execute the cursor again to fetch rows from the begining
+execute the cursor again to fetch rows from the beginning
 
 
 ```php
@@ -4231,7 +4231,7 @@ $result->setFetchMode(
         
 <h1 id="db-resultinterface">Interface Phalcon\Db\ResultInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/db/resultinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Db/ResultInterface.zep)
 
 | Namespace  | Phalcon\Db |
 
@@ -4249,9 +4249,9 @@ certain row
 ```php
 public function execute(): bool;
 ```
-Allows to executes the statement again. Some database systems don't
+Allows to execute the statement again. Some database systems don't
 support scrollable cursors. So, as cursors are forward only, we need to
-execute the cursor again to fetch rows from the begining
+execute the cursor again to fetch rows from the beginning
 
 
 ```php

--- a/en/api/phalcon_debug.md
+++ b/en/api/phalcon_debug.md
@@ -11,7 +11,7 @@ title: 'Phalcon\Debug'
         
 <h1 id="debug">Class Phalcon\Debug</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/debug.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Debug.zep)
 
 | Namespace  | Phalcon |
 | Uses       | ErrorException, Phalcon\Helper\Arr, Phalcon\Version, Phalcon\Tag, ReflectionClass, ReflectionFunction |
@@ -187,7 +187,7 @@ Shows a backtrace item
         
 <h1 id="debug-dump">Class Phalcon\Debug\Dump</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/debug/dump.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Debug/Dump.zep)
 
 | Namespace  | Phalcon\Debug |
 | Uses       | Phalcon\Di, Phalcon\Helper\Json, Reflection, ReflectionClass, ReflectionProperty, stdClass |
@@ -323,7 +323,7 @@ Prepare an HTML string of information about a single variable.
         
 <h1 id="debug-exception">Class Phalcon\Debug\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/debug/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Debug/Exception.zep)
 
 | Namespace  | Phalcon\Debug |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_di.md
+++ b/en/api/phalcon_di.md
@@ -21,7 +21,7 @@ title: 'Phalcon\Di'
         
 <h1 id="di">Class Phalcon\Di</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Di\Service, Phalcon\Di\DiInterface, Phalcon\Di\Exception, Phalcon\Di\Exception\ServiceResolutionException, Phalcon\Config\Adapter\Php, Phalcon\Config\Adapter\Yaml, Phalcon\Di\ServiceInterface, Phalcon\Events\ManagerInterface, Phalcon\Di\InjectionAwareInterface, Phalcon\Di\ServiceProviderInterface |
@@ -342,7 +342,7 @@ Loads services from a Config object.
         
 <h1 id="di-abstractinjectionaware">Abstract Class Phalcon\Di\AbstractInjectionAware</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/abstractinjectionaware.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/AbstractInjectionAware.zep)
 
 | Namespace  | Phalcon\Di |
 | Implements | InjectionAwareInterface |
@@ -378,7 +378,7 @@ Sets the dependency injector
         
 <h1 id="di-diinterface">Interface Phalcon\Di\DiInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/diinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/DiInterface.zep)
 
 | Namespace  | Phalcon\Di |
 | Uses       | ArrayAccess |
@@ -480,7 +480,7 @@ Registers an "always shared" service in the services container
         
 <h1 id="di-exception">Class Phalcon\Di\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/Exception.zep)
 
 | Namespace  | Phalcon\Di |
 | Extends    | \Phalcon\Exception |
@@ -491,7 +491,7 @@ Exceptions thrown in Phalcon\Di will use this class
         
 <h1 id="di-exception-serviceresolutionexception">Class Phalcon\Di\Exception\ServiceResolutionException</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/exception/serviceresolutionexception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/Exception/ServiceResolutionException.zep)
 
 | Namespace  | Phalcon\Di\Exception |
 | Extends    | \Phalcon\Di\Exception |
@@ -502,7 +502,7 @@ Exceptions thrown in Phalcon\Di will use this class
         
 <h1 id="di-factorydefault">Class Phalcon\Di\FactoryDefault</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/factorydefault.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/FactoryDefault.zep)
 
 | Namespace  | Phalcon\Di |
 | Uses       | Phalcon\Filter\FilterFactory |
@@ -525,7 +525,7 @@ Phalcon\Di\FactoryDefault constructor
         
 <h1 id="di-factorydefault-cli">Class Phalcon\Di\FactoryDefault\Cli</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/factorydefault/cli.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/FactoryDefault/Cli.zep)
 
 | Namespace  | Phalcon\Di\FactoryDefault |
 | Uses       | Phalcon\Di\FactoryDefault, Phalcon\Di\Service, Phalcon\Filter\FilterFactory |
@@ -550,7 +550,7 @@ Phalcon\Di\FactoryDefault\Cli constructor
         
 <h1 id="di-injectable">Abstract Class Phalcon\Di\Injectable</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/injectable.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/Injectable.zep)
 
 | Namespace  | Phalcon\Di |
 | Uses       | Phalcon\Di, Phalcon\Session\BagInterface |
@@ -625,7 +625,7 @@ Sets the dependency injector
         
 <h1 id="di-injectionawareinterface">Interface Phalcon\Di\InjectionAwareInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/injectionawareinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/InjectionAwareInterface.zep)
 
 | Namespace  | Phalcon\Di |
 
@@ -650,7 +650,7 @@ Sets the dependency injector
         
 <h1 id="di-service">Class Phalcon\Di\Service</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/service.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/Service.zep)
 
 | Namespace  | Phalcon\Di |
 | Uses       | Closure, Phalcon\Di\Exception\ServiceResolutionException, Phalcon\Di\Service\Builder |
@@ -756,7 +756,7 @@ Sets/Resets the shared instance related to the service
         
 <h1 id="di-service-builder">Class Phalcon\Di\Service\Builder</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/service/builder.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/Service/Builder.zep)
 
 | Namespace  | Phalcon\Di\Service |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\Exception |
@@ -779,7 +779,7 @@ Builds a service using a complex service definition
         
 <h1 id="di-serviceinterface">Interface Phalcon\Di\ServiceInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/serviceinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/ServiceInterface.zep)
 
 | Namespace  | Phalcon\Di |
 
@@ -842,7 +842,7 @@ Sets if the service is shared or not
         
 <h1 id="di-serviceproviderinterface">Interface Phalcon\Di\ServiceProviderInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/di/serviceproviderinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Di/ServiceProviderInterface.zep)
 
 | Namespace  | Phalcon\Di |
 

--- a/en/api/phalcon_dispatcher.md
+++ b/en/api/phalcon_dispatcher.md
@@ -11,7 +11,7 @@ title: 'Phalcon\Dispatcher'
         
 <h1 id="dispatcher-abstractdispatcher">Abstract Class Phalcon\Dispatcher\AbstractDispatcher</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/dispatcher/abstractdispatcher.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Dispatcher/AbstractDispatcher.zep)
 
 | Namespace  | Phalcon\Dispatcher |
 | Uses       | Exception, Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Dispatcher\Exception, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface, Phalcon\Filter\FilterInterface, Phalcon\Mvc\Model\Binder, Phalcon\Mvc\Model\BinderInterface |
@@ -379,7 +379,7 @@ protected function toCamelCase( string $input ): string;
         
 <h1 id="dispatcher-dispatcherinterface">Interface Phalcon\Dispatcher\DispatcherInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/dispatcher/dispatcherinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Dispatcher/DispatcherInterface.zep)
 
 | Namespace  | Phalcon\Dispatcher |
 
@@ -508,7 +508,7 @@ Sets action params to be dispatched
         
 <h1 id="dispatcher-exception">Class Phalcon\Dispatcher\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/dispatcher/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Dispatcher/Exception.zep)
 
 | Namespace  | Phalcon\Dispatcher |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_domain.md
+++ b/en/api/phalcon_domain.md
@@ -14,7 +14,7 @@ title: 'Phalcon\Domain'
         
 <h1 id="domain-payload-payload">Class Phalcon\Domain\Payload\Payload</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/domain/payload/payload.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Domain/Payload/Payload.zep)
 
 | Namespace  | Phalcon\Domain\Payload |
 | Uses       | Throwable |
@@ -146,7 +146,7 @@ Sets the payload status.
         
 <h1 id="domain-payload-payloadfactory">Class Phalcon\Domain\Payload\PayloadFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/domain/payload/payloadfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Domain/Payload/PayloadFactory.zep)
 
 | Namespace  | Phalcon\Domain\Payload |
 
@@ -164,7 +164,7 @@ Instantiate a new object
         
 <h1 id="domain-payload-payloadinterface">Interface Phalcon\Domain\Payload\PayloadInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/domain/payload/payloadinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Domain/Payload/PayloadInterface.zep)
 
 | Namespace  | Phalcon\Domain\Payload |
 | Extends    | ReadableInterface |
@@ -175,7 +175,7 @@ This interface is used for consumers
         
 <h1 id="domain-payload-readableinterface">Interface Phalcon\Domain\Payload\ReadableInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/domain/payload/readableinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Domain/Payload/ReadableInterface.zep)
 
 | Namespace  | Phalcon\Domain\Payload |
 | Uses       | Throwable |
@@ -236,7 +236,7 @@ Gets the status of this payload.
         
 <h1 id="domain-payload-status">Class Phalcon\Domain\Payload\Status</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/domain/payload/status.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Domain/Payload/Status.zep)
 
 | Namespace  | Phalcon\Domain\Payload |
 
@@ -278,7 +278,7 @@ Instantiation not allowed.
         
 <h1 id="domain-payload-writeableinterface">Interface Phalcon\Domain\Payload\WriteableInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/domain/payload/writeableinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Domain/Payload/WriteableInterface.zep)
 
 | Namespace  | Phalcon\Domain\Payload |
 | Uses       | Throwable |

--- a/en/api/phalcon_escaper.md
+++ b/en/api/phalcon_escaper.md
@@ -11,7 +11,7 @@ title: 'Phalcon\Escaper'
         
 <h1 id="escaper">Class Phalcon\Escaper</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/escaper.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Escaper.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Escaper\EscaperInterface, Phalcon\Escaper\Exception |
@@ -141,7 +141,7 @@ $escaper->setHtmlQuoteType(ENT_XHTML);
         
 <h1 id="escaper-escaperinterface">Interface Phalcon\Escaper\EscaperInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/escaper/escaperinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Escaper/EscaperInterface.zep)
 
 | Namespace  | Phalcon\Escaper |
 
@@ -203,7 +203,7 @@ Sets the HTML quoting type for htmlspecialchars
         
 <h1 id="escaper-exception">Class Phalcon\Escaper\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/escaper/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Escaper/Exception.zep)
 
 | Namespace  | Phalcon\Escaper |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_events.md
+++ b/en/api/phalcon_events.md
@@ -14,7 +14,7 @@ title: 'Phalcon\Events'
         
 <h1 id="events-event">Class Phalcon\Events\Event</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/events/event.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Events/Event.zep)
 
 | Namespace  | Phalcon\Events |
 | Implements | EventInterface |
@@ -142,7 +142,7 @@ if ($event->isCancelable()) {
         
 <h1 id="events-eventinterface">Interface Phalcon\Events\EventInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/events/eventinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Events/EventInterface.zep)
 
 | Namespace  | Phalcon\Events |
 
@@ -198,7 +198,7 @@ Stops the event preventing propagation
         
 <h1 id="events-eventsawareinterface">Interface Phalcon\Events\EventsAwareInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/events/eventsawareinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Events/EventsAwareInterface.zep)
 
 | Namespace  | Phalcon\Events |
 
@@ -225,7 +225,7 @@ Sets the events manager
         
 <h1 id="events-exception">Class Phalcon\Events\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/events/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Events/Exception.zep)
 
 | Namespace  | Phalcon\Events |
 | Extends    | \Phalcon\Exception |
@@ -238,7 +238,7 @@ Exceptions thrown in Phalcon\Events will use this class
         
 <h1 id="events-manager">Class Phalcon\Events\Manager</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/events/manager.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Events/Manager.zep)
 
 | Namespace  | Phalcon\Events |
 | Uses       | Closure, SplPriorityQueue |
@@ -368,7 +368,7 @@ by every registered listener in a single fire
         
 <h1 id="events-managerinterface">Interface Phalcon\Events\ManagerInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/events/managerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Events/ManagerInterface.zep)
 
 | Namespace  | Phalcon\Events |
 

--- a/en/api/phalcon_exception.md
+++ b/en/api/phalcon_exception.md
@@ -9,7 +9,7 @@ title: 'Phalcon\Exception'
         
 <h1 id="exception">Class Phalcon\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Exception.zep)
 
 | Namespace  | Phalcon |
 | Extends    | \Exception |

--- a/en/api/phalcon_factory.md
+++ b/en/api/phalcon_factory.md
@@ -10,7 +10,7 @@ title: 'Phalcon\Factory'
         
 <h1 id="factory-abstractfactory">Abstract Class Phalcon\Factory\AbstractFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/factory/abstractfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Factory/AbstractFactory.zep)
 
 | Namespace  | Phalcon\Factory |
 | Uses       | Phalcon\Config |
@@ -66,7 +66,7 @@ AdapterFactory constructor.
         
 <h1 id="factory-exception">Class Phalcon\Factory\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/factory/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Factory/Exception.zep)
 
 | Namespace  | Phalcon\Factory |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_filter.md
+++ b/en/api/phalcon_filter.md
@@ -33,7 +33,7 @@ title: 'Phalcon\Filter'
         
 <h1 id="filter">Class Phalcon\Filter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Closure, Phalcon\Filter\Exception, Phalcon\Filter\FilterInterface |
@@ -124,7 +124,7 @@ Loads the objects in the internal mapper array
         
 <h1 id="filter-exception">Class Phalcon\Filter\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Exception.zep)
 
 | Namespace  | Phalcon\Filter |
 | Extends    | \Phalcon\Exception |
@@ -137,7 +137,7 @@ Exceptions thrown in Phalcon\Filter will use this class
         
 <h1 id="filter-filterfactory">Class Phalcon\Filter\FilterFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/filterfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/FilterFactory.zep)
 
 | Namespace  | Phalcon\Filter |
 | Uses       | Phalcon\Filter |
@@ -154,7 +154,7 @@ file that was distributed with this source code.
 ```php
 public function newInstance(): FilterInterface;
 ```
-Returns a Locator object with all the helpers defined in anonynous
+Returns a Locator object with all the helpers defined in anonymous
 functions
 
 
@@ -167,7 +167,7 @@ protected function getAdapters(): array;
         
 <h1 id="filter-filterinterface">Interface Phalcon\Filter\FilterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/filterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/FilterInterface.zep)
 
 | Namespace  | Phalcon\Filter |
 
@@ -185,7 +185,7 @@ Sanitizes a value with a specified single or set of sanitizers
         
 <h1 id="filter-sanitize-absint">Class Phalcon\Filter\Sanitize\AbsInt</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/absint.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/AbsInt.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -205,7 +205,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-alnum">Class Phalcon\Filter\Sanitize\Alnum</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/alnum.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Alnum.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -225,7 +225,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-alpha">Class Phalcon\Filter\Sanitize\Alpha</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/alpha.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Alpha.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -245,7 +245,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-boolval">Class Phalcon\Filter\Sanitize\BoolVal</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/boolval.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/BoolVal.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -265,7 +265,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-email">Class Phalcon\Filter\Sanitize\Email</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/email.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Email.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -285,7 +285,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-floatval">Class Phalcon\Filter\Sanitize\FloatVal</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/floatval.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/FloatVal.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -305,7 +305,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-intval">Class Phalcon\Filter\Sanitize\IntVal</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/intval.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/IntVal.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -325,7 +325,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-lower">Class Phalcon\Filter\Sanitize\Lower</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/lower.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Lower.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -345,7 +345,7 @@ public function __invoke( string $input );
         
 <h1 id="filter-sanitize-lowerfirst">Class Phalcon\Filter\Sanitize\LowerFirst</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/lowerfirst.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/LowerFirst.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -365,7 +365,7 @@ public function __invoke( string $input );
         
 <h1 id="filter-sanitize-regex">Class Phalcon\Filter\Sanitize\Regex</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/regex.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Regex.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -385,7 +385,7 @@ public function __invoke( mixed $input, mixed $pattern, mixed $replace );
         
 <h1 id="filter-sanitize-remove">Class Phalcon\Filter\Sanitize\Remove</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/remove.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Remove.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -405,7 +405,7 @@ public function __invoke( mixed $input, mixed $replace );
         
 <h1 id="filter-sanitize-replace">Class Phalcon\Filter\Sanitize\Replace</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/replace.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Replace.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -425,7 +425,7 @@ public function __invoke( mixed $input, mixed $from, mixed $to );
         
 <h1 id="filter-sanitize-special">Class Phalcon\Filter\Sanitize\Special</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/special.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Special.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -445,7 +445,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-specialfull">Class Phalcon\Filter\Sanitize\SpecialFull</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/specialfull.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/SpecialFull.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -465,7 +465,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-stringval">Class Phalcon\Filter\Sanitize\StringVal</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/stringval.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/StringVal.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -485,7 +485,7 @@ public function __invoke( mixed $input );
         
 <h1 id="filter-sanitize-striptags">Class Phalcon\Filter\Sanitize\Striptags</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/striptags.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Striptags.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -505,7 +505,7 @@ public function __invoke( string $input );
         
 <h1 id="filter-sanitize-trim">Class Phalcon\Filter\Sanitize\Trim</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/trim.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Trim.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -525,7 +525,7 @@ public function __invoke( string $input );
         
 <h1 id="filter-sanitize-upper">Class Phalcon\Filter\Sanitize\Upper</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/upper.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Upper.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -545,7 +545,7 @@ public function __invoke( string $input );
         
 <h1 id="filter-sanitize-upperfirst">Class Phalcon\Filter\Sanitize\UpperFirst</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/upperfirst.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/UpperFirst.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -565,7 +565,7 @@ public function __invoke( string $input );
         
 <h1 id="filter-sanitize-upperwords">Class Phalcon\Filter\Sanitize\UpperWords</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/upperwords.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/UpperWords.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 
@@ -585,7 +585,7 @@ public function __invoke( string $input );
         
 <h1 id="filter-sanitize-url">Class Phalcon\Filter\Sanitize\Url</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/filter/sanitize/url.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Filter/Sanitize/Url.zep)
 
 | Namespace  | Phalcon\Filter\Sanitize |
 

--- a/en/api/phalcon_flash.md
+++ b/en/api/phalcon_flash.md
@@ -13,7 +13,7 @@ title: 'Phalcon\Flash'
         
 <h1 id="flash-abstractflash">Abstract Class Phalcon\Flash\AbstractFlash</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/flash/abstractflash.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Flash/AbstractFlash.zep)
 
 | Namespace  | Phalcon\Flash |
 | Uses       | Phalcon\Di, Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Escaper\EscaperInterface, Phalcon\Session\ManagerInterface |
@@ -200,7 +200,7 @@ $flash->warning("Hey, this is important");
         
 <h1 id="flash-direct">Class Phalcon\Flash\Direct</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/flash/direct.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Flash/Direct.zep)
 
 | Namespace  | Phalcon\Flash |
 | Extends    | AbstractFlash |
@@ -226,7 +226,7 @@ Prints the messages accumulated in the flasher
         
 <h1 id="flash-exception">Class Phalcon\Flash\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/flash/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Flash/Exception.zep)
 
 | Namespace  | Phalcon\Flash |
 | Extends    | \Phalcon\Exception |
@@ -237,7 +237,7 @@ Exceptions thrown in Phalcon\Flash will use this class
         
 <h1 id="flash-flashinterface">Interface Phalcon\Flash\FlashInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/flash/flashinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Flash/FlashInterface.zep)
 
 | Namespace  | Phalcon\Flash |
 
@@ -281,7 +281,7 @@ Shows a HTML warning message
         
 <h1 id="flash-session">Class Phalcon\Flash\Session</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/flash/session.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Flash/Session.zep)
 
 | Namespace  | Phalcon\Flash |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Session\ManagerInterface |

--- a/en/api/phalcon_forms.md
+++ b/en/api/phalcon_forms.md
@@ -25,7 +25,7 @@ title: 'Phalcon\Forms'
         
 <h1 id="forms-element-abstractelement">Abstract Class Phalcon\Forms\Element\AbstractElement</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/abstractelement.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/AbstractElement.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | InvalidArgumentException, Phalcon\Forms\Form, Phalcon\Forms\Exception, Phalcon\Messages\MessageInterface, Phalcon\Messages\Messages, Phalcon\Tag, Phalcon\Validation\ValidatorInterface |
@@ -272,7 +272,7 @@ Sets options for the element
         
 <h1 id="forms-element-check">Class Phalcon\Forms\Element\Check</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/check.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Check.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -294,7 +294,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-date">Class Phalcon\Forms\Element\Date</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/date.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Date.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -314,7 +314,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-elementinterface">Interface Phalcon\Forms\Element\ElementInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/elementinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/ElementInterface.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Forms\Form, Phalcon\Messages\MessageInterface, Phalcon\Messages\Messages, Phalcon\Validation\ValidatorInterface |
@@ -520,7 +520,7 @@ Sets options for the element
         
 <h1 id="forms-element-email">Class Phalcon\Forms\Element\Email</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/email.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Email.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -542,7 +542,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-file">Class Phalcon\Forms\Element\File</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/file.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/File.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -562,7 +562,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-hidden">Class Phalcon\Forms\Element\Hidden</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/hidden.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Hidden.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -584,7 +584,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-numeric">Class Phalcon\Forms\Element\Numeric</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/numeric.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Numeric.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -606,7 +606,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-password">Class Phalcon\Forms\Element\Password</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/password.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Password.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -628,7 +628,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-radio">Class Phalcon\Forms\Element\Radio</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/radio.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Radio.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -650,7 +650,7 @@ Renders the element widget returning html
         
 <h1 id="forms-element-select">Class Phalcon\Forms\Element\Select</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/select.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Select.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag\Select |
@@ -708,7 +708,7 @@ Set the choice's options
         
 <h1 id="forms-element-submit">Class Phalcon\Forms\Element\Submit</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/submit.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Submit.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -728,7 +728,7 @@ Renders the element widget
         
 <h1 id="forms-element-text">Class Phalcon\Forms\Element\Text</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/text.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/Text.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -750,7 +750,7 @@ Renders the element widget
         
 <h1 id="forms-element-textarea">Class Phalcon\Forms\Element\TextArea</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/element/textarea.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Element/TextArea.zep)
 
 | Namespace  | Phalcon\Forms\Element |
 | Uses       | Phalcon\Tag |
@@ -770,7 +770,7 @@ Renders the element widget
         
 <h1 id="forms-exception">Class Phalcon\Forms\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Exception.zep)
 
 | Namespace  | Phalcon\Forms |
 | Extends    | \Phalcon\Exception |
@@ -781,7 +781,7 @@ Exceptions thrown in Phalcon\Forms will use this class
         
 <h1 id="forms-form">Class Phalcon\Forms\Form</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/form.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Form.zep)
 
 | Namespace  | Phalcon\Forms |
 | Uses       | Countable, Iterator, Phalcon\Di\Injectable, Phalcon\Di\DiInterface, Phalcon\Filter\FilterInterface, Phalcon\Forms\Element\ElementInterface, Phalcon\Html\Attributes, Phalcon\Html\Attributes\AttributesInterface, Phalcon\Messages\Messages, Phalcon\Tag, Phalcon\Validation, Phalcon\Validation\ValidationInterface |
@@ -1049,7 +1049,7 @@ Check if the current element in the iterator is valid
         
 <h1 id="forms-manager">Class Phalcon\Forms\Manager</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/forms/manager.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Forms/Manager.zep)
 
 | Namespace  | Phalcon\Forms |
 

--- a/en/api/phalcon_helper.md
+++ b/en/api/phalcon_helper.md
@@ -14,7 +14,7 @@ title: 'Phalcon\Helper'
         
 <h1 id="helper-arr">Class Phalcon\Helper\Arr</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/helper/arr.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Helper/Arr.zep)
 
 | Namespace  | Phalcon\Helper |
 | Uses       | stdClass |
@@ -199,7 +199,7 @@ the collection, false otherwise.
 final public static function validateAny( array $collection, mixed $method = null ): bool;
 ```
 Returns true if the provided function returns true for at least one
-element fo the collection, false otherwise.
+element of the collection, false otherwise.
 
 
 @return bool
@@ -219,7 +219,7 @@ by the keys obtained from the elements of a whitelist
         
 <h1 id="helper-exception">Class Phalcon\Helper\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/helper/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Helper/Exception.zep)
 
 | Namespace  | Phalcon\Helper |
 | Extends    | \Phalcon\Exception |
@@ -230,7 +230,7 @@ Exceptions thrown in Phalcon\Helper will use this class
         
 <h1 id="helper-fs">Class Phalcon\Helper\Fs</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/helper/fs.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Helper/Fs.zep)
 
 | Namespace  | Phalcon\Helper |
 
@@ -253,7 +253,7 @@ see https://bugs.php.net/bug.php?id=37738
         
 <h1 id="helper-json">Class Phalcon\Helper\Json</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/helper/json.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Helper/Json.zep)
 
 | Namespace  | Phalcon\Helper |
 | Uses       | InvalidArgumentException |
@@ -316,7 +316,7 @@ echo Json::encode($data);
         
 <h1 id="helper-number">Class Phalcon\Helper\Number</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/helper/number.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Helper/Number.zep)
 
 | Namespace  | Phalcon\Helper |
 
@@ -336,7 +336,7 @@ Helper method to get an array element or a default
         
 <h1 id="helper-str">Class Phalcon\Helper\Str</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/helper/str.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Helper/Str.zep)
 
 | Namespace  | Phalcon\Helper |
 | Uses       | RuntimeException |
@@ -397,7 +397,7 @@ echo $str;   // /tmp/folder_1/folder_2/folder_3/
 ```php
 final public static function countVowels( string $text ): int;
 ```
-Retuns number of vowels in provided string. Uses a regular expression
+Returns number of vowels in provided string. Uses a regular expression
 to count the number of vowels (A, E, I, O, U) in a string.
 
 
@@ -407,7 +407,7 @@ to count the number of vowels (A, E, I, O, U) in a string.
 ```php
 final public static function decapitalize( string $text, bool $upperRest = bool, string $encoding = string ): string;
 ```
-Decapitalizes the first letter of the sring and then adds it with rest
+Decapitalizes the first letter of the string and then adds it with rest
 of the string. Omit the upperRest parameter to keep the rest of the
 string intact, or set it to true to convert to uppercase.
 

--- a/en/api/phalcon_html.md
+++ b/en/api/phalcon_html.md
@@ -32,7 +32,7 @@ title: 'Phalcon\Html'
         
 <h1 id="html-attributes">Class Phalcon\Html\Attributes</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/attributes.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Attributes.zep)
 
 | Namespace  | Phalcon\Html |
 | Uses       | Phalcon\Collection, Phalcon\Html\Attributes\RenderInterface, Phalcon\Tag |
@@ -59,7 +59,7 @@ Render attributes as HTML attributes
         
 <h1 id="html-attributes-attributesinterface">Interface Phalcon\Html\Attributes\AttributesInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/attributes/attributesinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Attributes/AttributesInterface.zep)
 
 | Namespace  | Phalcon\Html\Attributes |
 | Uses       | Phalcon\Html\Attributes |
@@ -86,7 +86,7 @@ Set Attributes
         
 <h1 id="html-attributes-renderinterface">Interface Phalcon\Html\Attributes\RenderInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/attributes/renderinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Attributes/RenderInterface.zep)
 
 | Namespace  | Phalcon\Html\Attributes |
 
@@ -106,7 +106,7 @@ Generate a string represetation
         
 <h1 id="html-breadcrumbs">Class Phalcon\Html\Breadcrumbs</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/breadcrumbs.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Breadcrumbs.zep)
 
 | Namespace  | Phalcon\Html |
 | Uses       | Phalcon\Di\DiInterface |
@@ -211,7 +211,7 @@ Returns the internal breadcrumbs array
         
 <h1 id="html-exception">Class Phalcon\Html\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Exception.zep)
 
 | Namespace  | Phalcon\Html |
 | Extends    | \Phalcon\Exception |
@@ -224,7 +224,7 @@ Exceptions thrown in Phalcon\Html\Tag will use this class
         
 <h1 id="html-helper-abstracthelper">Abstract Class Phalcon\Html\Helper\AbstractHelper</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/abstracthelper.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/AbstractHelper.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Uses       | Phalcon\Html\Exception, Phalcon\Escaper\EscaperInterface |
@@ -287,7 +287,7 @@ Produces a self close tag i.e. <img />
         
 <h1 id="html-helper-anchor">Class Phalcon\Html\Helper\Anchor</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/anchor.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Anchor.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -310,7 +310,7 @@ public function __invoke( string $href, string $text, array $attributes = [] ): 
         
 <h1 id="html-helper-anchorraw">Class Phalcon\Html\Helper\AnchorRaw</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/anchorraw.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/AnchorRaw.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -333,7 +333,7 @@ public function __invoke( string $href, string $text, array $attributes = [] ): 
         
 <h1 id="html-helper-body">Class Phalcon\Html\Helper\Body</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/body.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Body.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -354,7 +354,7 @@ public function __invoke( array $attributes = [] ): string;
         
 <h1 id="html-helper-button">Class Phalcon\Html\Helper\Button</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/button.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Button.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -376,7 +376,7 @@ public function __invoke( string $text, array $attributes = [] ): string;
         
 <h1 id="html-helper-close">Class Phalcon\Html\Helper\Close</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/close.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Close.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -398,7 +398,7 @@ public function __invoke( string $tag ): string;
         
 <h1 id="html-helper-element">Class Phalcon\Html\Helper\Element</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/element.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Element.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -421,7 +421,7 @@ public function __invoke( string $tag, string $text, array $attributes = [] ): s
         
 <h1 id="html-helper-elementraw">Class Phalcon\Html\Helper\ElementRaw</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/elementraw.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/ElementRaw.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Uses       | Phalcon\Html\Exception |
@@ -445,7 +445,7 @@ public function __invoke( string $tag, string $text, array $attributes = [] ): s
         
 <h1 id="html-helper-form">Class Phalcon\Html\Helper\Form</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/form.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Form.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -466,7 +466,7 @@ public function __invoke( array $attributes = [] ): string;
         
 <h1 id="html-helper-img">Class Phalcon\Html\Helper\Img</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/img.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Img.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Uses       | Phalcon\Html\Exception |
@@ -490,7 +490,7 @@ public function __invoke( string $src, array $attributes = [] ): string;
         
 <h1 id="html-helper-label">Class Phalcon\Html\Helper\Label</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/label.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/Label.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Uses       | Phalcon\Html\Exception |
@@ -514,7 +514,7 @@ public function __invoke( array $attributes = [] ): string;
         
 <h1 id="html-helper-textarea">Class Phalcon\Html\Helper\TextArea</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/helper/textarea.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Helper/TextArea.zep)
 
 | Namespace  | Phalcon\Html\Helper |
 | Extends    | AbstractHelper |
@@ -536,7 +536,7 @@ public function __invoke( string $text, array $attributes = [] ): string;
         
 <h1 id="html-link-evolvablelink">Class Phalcon\Html\Link\EvolvableLink</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/link/evolvablelink.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Link/EvolvableLink.zep)
 
 | Namespace  | Phalcon\Html\Link |
 | Uses       | Psr\Link\EvolvableLinkInterface |
@@ -626,7 +626,7 @@ normally without errors.
         
 <h1 id="html-link-evolvablelinkprovider">Class Phalcon\Html\Link\EvolvableLinkProvider</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/link/evolvablelinkprovider.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Link/EvolvableLinkProvider.zep)
 
 | Namespace  | Phalcon\Html\Link |
 | Uses       | Psr\Link\EvolvableLinkProviderInterface, Psr\Link\LinkInterface |
@@ -671,7 +671,7 @@ object already in the collection.
         
 <h1 id="html-link-link">Class Phalcon\Html\Link\Link</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/link/link.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Link/Link.zep)
 
 | Namespace  | Phalcon\Html\Link |
 | Uses       | Phalcon\Collection, Psr\Link\LinkInterface |
@@ -778,7 +778,7 @@ Determines if a href is a templated link or not.
         
 <h1 id="html-link-linkprovider">Class Phalcon\Html\Link\LinkProvider</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/link/linkprovider.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Link/LinkProvider.zep)
 
 | Namespace  | Phalcon\Html\Link |
 | Uses       | Psr\Link\LinkInterface, Psr\Link\LinkProviderInterface |
@@ -843,7 +843,7 @@ Returns the object hash key
         
 <h1 id="html-link-serializer-header">Class Phalcon\Html\Link\Serializer\Header</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/link/serializer/header.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Link/Serializer/Header.zep)
 
 | Namespace  | Phalcon\Html\Link\Serializer |
 | Uses       | Psr\Link\EvolvableLinkInterface |
@@ -863,7 +863,7 @@ Serializes all the passed links to a HTTP link header
         
 <h1 id="html-link-serializer-serializerinterface">Interface Phalcon\Html\Link\Serializer\SerializerInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/link/serializer/serializerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/Link/Serializer/SerializerInterface.zep)
 
 | Namespace  | Phalcon\Html\Link\Serializer |
 
@@ -881,7 +881,7 @@ Serializer method
         
 <h1 id="html-tagfactory">Class Phalcon\Html\TagFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/html/tagfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Html/TagFactory.zep)
 
 | Namespace  | Phalcon\Html |
 | Uses       | Phalcon\Escaper, Phalcon\Escaper\EscaperInterface, Phalcon\Factory\AbstractFactory |

--- a/en/api/phalcon_http.md
+++ b/en/api/phalcon_http.md
@@ -44,7 +44,7 @@ title: 'Phalcon\Http'
         
 <h1 id="http-cookie">Class Phalcon\Http\Cookie</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/cookie.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Cookie.zep)
 
 | Namespace  | Phalcon\Http |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Crypt\CryptInterface, Phalcon\Crypt\Mismatch, Phalcon\Filter\FilterInterface, Phalcon\Helper\Arr, Phalcon\Http\Response\Exception, Phalcon\Http\Cookie\CookieInterface, Phalcon\Http\Cookie\Exception, Phalcon\Session\ManagerInterface |
@@ -289,7 +289,7 @@ Assert the cookie's key is enough long.
         
 <h1 id="http-cookie-cookieinterface">Interface Phalcon\Http\Cookie\CookieInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/cookie/cookieinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Cookie/CookieInterface.zep)
 
 | Namespace  | Phalcon\Http\Cookie |
 
@@ -418,7 +418,7 @@ Sets if the cookie must be encrypted/decrypted automatically
         
 <h1 id="http-cookie-exception">Class Phalcon\Http\Cookie\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/cookie/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Cookie/Exception.zep)
 
 | Namespace  | Phalcon\Http\Cookie |
 | Extends    | \Phalcon\Exception |
@@ -431,7 +431,7 @@ Exceptions thrown in Phalcon\Http\Cookie will use this class.
         
 <h1 id="http-message-abstractcommon">Abstract Class Phalcon\Http\Message\AbstractCommon</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/abstractcommon.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/AbstractCommon.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Http\Message\Exception\InvalidArgumentException |
@@ -470,7 +470,7 @@ clone of the object back
         
 <h1 id="http-message-abstractmessage">Abstract Class Phalcon\Http\Message\AbstractMessage</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/abstractmessage.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/AbstractMessage.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Collection, Phalcon\Http\Message\Exception\InvalidArgumentException, Psr\Http\Message\StreamInterface, Psr\Http\Message\UriInterface |
@@ -808,7 +808,7 @@ Checks the protocol
         
 <h1 id="http-message-abstractrequest">Abstract Class Phalcon\Http\Message\AbstractRequest</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/abstractrequest.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/AbstractRequest.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Collection, Phalcon\Http\Message\Exception\InvalidArgumentException, Psr\Http\Message\UriInterface |
@@ -969,7 +969,7 @@ Sets a valid Uri
         
 <h1 id="http-message-exception-invalidargumentexception">Class Phalcon\Http\Message\Exception\InvalidArgumentException</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/exception/invalidargumentexception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Exception/InvalidArgumentException.zep)
 
 | Namespace  | Phalcon\Http\Message\Exception |
 | Uses       | Throwable |
@@ -987,7 +987,7 @@ file that was distributed with this source code.
         
 <h1 id="http-message-request">Final Class Phalcon\Http\Message\Request</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/request.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Request.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Http\Message\Stream\Input, Phalcon\Http\Message\AbstractRequest, Psr\Http\Message\RequestInterface, Psr\Http\Message\StreamInterface, Psr\Http\Message\UriInterface |
@@ -1009,7 +1009,7 @@ Request constructor.
         
 <h1 id="http-message-requestfactory">Final Class Phalcon\Http\Message\RequestFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/requestfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/RequestFactory.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Psr\Http\Message\RequestInterface, Psr\Http\Message\RequestFactoryInterface, Psr\Http\Message\UriInterface |
@@ -1032,7 +1032,7 @@ Create a new request.
         
 <h1 id="http-message-response">Final Class Phalcon\Http\Message\Response</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/response.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Response.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Helper\Number, Phalcon\Http\Message\AbstractMessage, Phalcon\Http\Message\Exception\InvalidArgumentException, Psr\Http\Message\ResponseInterface |
@@ -1116,7 +1116,7 @@ updated status and reason phrase.
         
 <h1 id="http-message-responsefactory">Final Class Phalcon\Http\Message\ResponseFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/responsefactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/ResponseFactory.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Psr\Http\Message\ResponseInterface, Psr\Http\Message\ResponseFactoryInterface |
@@ -1142,7 +1142,7 @@ Create a new response.
         
 <h1 id="http-message-serverrequest">Final Class Phalcon\Http\Message\ServerRequest</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/serverrequest.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/ServerRequest.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Collection, Phalcon\Http\Message\Exception\InvalidArgumentException, Phalcon\Http\Message\Stream\Input, Psr\Http\Message\ServerRequestInterface, Psr\Http\Message\StreamInterface, Psr\Http\Message\UploadedFileInterface, Psr\Http\Message\UriInterface |
@@ -1415,7 +1415,7 @@ the attribute.
         
 <h1 id="http-message-serverrequestfactory">Class Phalcon\Http\Message\ServerRequestFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/serverrequestfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/ServerRequestFactory.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Collection, Phalcon\Helper\Arr, Phalcon\Http\Message\Exception\InvalidArgumentException, Psr\Http\Message\ServerRequestFactoryInterface, Psr\Http\Message\ServerRequestInterface, Psr\Http\Message\UriInterface, Psr\Http\Message\UploadedFileInterface |
@@ -1471,7 +1471,7 @@ Returns the apache_request_headers if it exists
         
 <h1 id="http-message-stream">Class Phalcon\Http\Message\Stream</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/stream.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Stream.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Helper\Arr, Exception, Psr\Http\Message\StreamInterface, RuntimeException |
@@ -1641,7 +1641,7 @@ Write data to the stream.
         
 <h1 id="http-message-stream-input">Class Phalcon\Http\Message\Stream\Input</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/stream/input.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Stream/Input.zep)
 
 | Namespace  | Phalcon\Http\Message\Stream |
 | Uses       | Phalcon\Http\Message\Stream |
@@ -1722,7 +1722,7 @@ Read data from the stream.
         
 <h1 id="http-message-stream-memory">Class Phalcon\Http\Message\Stream\Memory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/stream/memory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Stream/Memory.zep)
 
 | Namespace  | Phalcon\Http\Message\Stream |
 | Uses       | Phalcon\Http\Message\Stream |
@@ -1746,7 +1746,7 @@ Constructor
         
 <h1 id="http-message-stream-temp">Class Phalcon\Http\Message\Stream\Temp</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/stream/temp.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Stream/Temp.zep)
 
 | Namespace  | Phalcon\Http\Message\Stream |
 | Uses       | Phalcon\Http\Message\Stream |
@@ -1770,7 +1770,7 @@ Constructor
         
 <h1 id="http-message-streamfactory">Final Class Phalcon\Http\Message\StreamFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/streamfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/StreamFactory.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Http\Message\Exception\InvalidArgumentException, Psr\Http\Message\StreamFactoryInterface, Psr\Http\Message\StreamInterface |
@@ -1819,7 +1819,7 @@ The stream MUST be readable and may be writable.
         
 <h1 id="http-message-uploadedfile">Final Class Phalcon\Http\Message\UploadedFile</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/uploadedfile.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/UploadedFile.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Helper\Number, Phalcon\Helper\Arr, Phalcon\Helper\Str, Phalcon\Http\Message\Exception\InvalidArgumentException, Psr\Http\Message\StreamInterface, Psr\Http\Message\UploadedFileInterface, RuntimeException |
@@ -1995,7 +1995,7 @@ cannot guarantee writing to stream destinations.
         
 <h1 id="http-message-uploadedfilefactory">Final Class Phalcon\Http\Message\UploadedFileFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/uploadedfilefactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/UploadedFileFactory.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Psr\Http\Message\StreamInterface, Psr\Http\Message\UploadedFileInterface, Psr\Http\Message\UploadedFileFactoryInterface |
@@ -2025,7 +2025,7 @@ the stream.
         
 <h1 id="http-message-uri">Final Class Phalcon\Http\Message\Uri</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/uri.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/Uri.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Helper\Str, Phalcon\Http\Message\Exception\InvalidArgumentException, Psr\Http\Message\UriInterface |
@@ -2322,7 +2322,7 @@ Return an instance with the specified user information.
         
 <h1 id="http-message-urifactory">Final Class Phalcon\Http\Message\UriFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/message/urifactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Message/UriFactory.zep)
 
 | Namespace  | Phalcon\Http\Message |
 | Uses       | Psr\Http\Message\UriFactoryInterface, Psr\Http\Message\UriInterface |
@@ -2343,7 +2343,7 @@ functions
         
 <h1 id="http-request">Class Phalcon\Http\Request</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/request.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Request.zep)
 
 | Namespace  | Phalcon\Http |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Events\ManagerInterface, Phalcon\Filter\FilterInterface, Phalcon\Helper\Json, Phalcon\Http\Request\File, Phalcon\Http\Request\FileInterface, Phalcon\Http\Request\Exception, UnexpectedValueException, stdClass |
@@ -2926,7 +2926,7 @@ Smooth out $_FILES to have plain array with all files uploaded
         
 <h1 id="http-request-exception">Class Phalcon\Http\Request\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/request/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Request/Exception.zep)
 
 | Namespace  | Phalcon\Http\Request |
 | Extends    | \Phalcon\Exception |
@@ -2939,7 +2939,7 @@ Exceptions thrown in Phalcon\Http\Request will use this class
         
 <h1 id="http-request-file">Class Phalcon\Http\Request\File</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/request/file.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Request/File.zep)
 
 | Namespace  | Phalcon\Http\Request |
 | Implements | FileInterface |
@@ -3070,7 +3070,7 @@ Moves the temporary file to a destination within the application
         
 <h1 id="http-request-fileinterface">Interface Phalcon\Http\Request\FileInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/request/fileinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Request/FileInterface.zep)
 
 | Namespace  | Phalcon\Http\Request |
 
@@ -3128,7 +3128,7 @@ Move the temporary file to a destination
         
 <h1 id="http-requestinterface">Interface Phalcon\Http\RequestInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/requestinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/RequestInterface.zep)
 
 | Namespace  | Phalcon\Http |
 | Uses       | Phalcon\Http\Request\FileInterface, stdClass |
@@ -3552,7 +3552,7 @@ Returns the number of files available
         
 <h1 id="http-response">Class Phalcon\Http\Response</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/response.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Response.zep)
 
 | Namespace  | Phalcon\Http |
 | Uses       | DateTime, DateTimeZone, Phalcon\Di, Phalcon\Di\DiInterface, Phalcon\Helper\Fs, Phalcon\Helper\Json, Phalcon\Http\Response\Exception, Phalcon\Http\Response\HeadersInterface, Phalcon\Http\Response\CookiesInterface, Phalcon\Url\UrlInterface, Phalcon\Mvc\ViewInterface, Phalcon\Http\Response\Headers, Phalcon\Di\InjectionAwareInterface, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface |
@@ -3901,7 +3901,7 @@ $response->setStatusCode(404, "Not Found");
         
 <h1 id="http-response-cookies">Class Phalcon\Http\Response\Cookies</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/response/cookies.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Response/Cookies.zep)
 
 | Namespace  | Phalcon\Http\Response |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Http\Cookie\Exception, Phalcon\Http\Cookie\CookieInterface |
@@ -4072,7 +4072,7 @@ Set if cookies in the bag must be automatically encrypted/decrypted
         
 <h1 id="http-response-cookiesinterface">Interface Phalcon\Http\Response\CookiesInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/response/cookiesinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Response/CookiesInterface.zep)
 
 | Namespace  | Phalcon\Http\Response |
 | Uses       | Phalcon\Http\Cookie\CookieInterface |
@@ -4136,7 +4136,7 @@ Set if cookies in the bag must be automatically encrypted/decrypted
         
 <h1 id="http-response-exception">Class Phalcon\Http\Response\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/response/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Response/Exception.zep)
 
 | Namespace  | Phalcon\Http\Response |
 | Extends    | \Phalcon\Exception |
@@ -4149,7 +4149,7 @@ Exceptions thrown in Phalcon\Http\Response will use this class.
         
 <h1 id="http-response-headers">Class Phalcon\Http\Response\Headers</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/response/headers.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Response/Headers.zep)
 
 | Namespace  | Phalcon\Http\Response |
 | Implements | HeadersInterface |
@@ -4219,7 +4219,7 @@ Returns the current headers as an array
         
 <h1 id="http-response-headersinterface">Interface Phalcon\Http\Response\HeadersInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/response/headersinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Response/HeadersInterface.zep)
 
 | Namespace  | Phalcon\Http\Response |
 
@@ -4269,7 +4269,7 @@ Sets a raw header to be sent at the end of the request
         
 <h1 id="http-responseinterface">Interface Phalcon\Http\ResponseInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/responseinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/ResponseInterface.zep)
 
 | Namespace  | Phalcon\Http |
 | Uses       | DateTime, Phalcon\Http\Response\HeadersInterface |
@@ -4419,7 +4419,7 @@ Sets the HTTP response code
         
 <h1 id="http-server-abstractmiddleware">Abstract Class Phalcon\Http\Server\AbstractMiddleware</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/server/abstractmiddleware.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Server/AbstractMiddleware.zep)
 
 | Namespace  | Phalcon\Http\Server |
 | Uses       | Psr\Http\Message\ResponseInterface, Psr\Http\Message\ServerRequestInterface, Psr\Http\Server\MiddlewareInterface, Psr\Http\Server\RequestHandlerInterface |
@@ -4447,7 +4447,7 @@ request handler to do so.
         
 <h1 id="http-server-abstractrequesthandler">Abstract Class Phalcon\Http\Server\AbstractRequestHandler</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/http/server/abstractrequesthandler.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Http/Server/AbstractRequestHandler.zep)
 
 | Namespace  | Phalcon\Http\Server |
 | Uses       | Psr\Http\Message\ResponseInterface, Psr\Http\Message\ServerRequestInterface, Psr\Http\Server\RequestHandlerInterface |

--- a/en/api/phalcon_image.md
+++ b/en/api/phalcon_image.md
@@ -15,7 +15,7 @@ title: 'Phalcon\Image'
         
 <h1 id="image-adapter-abstractadapter">Abstract Class Phalcon\Image\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/image/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Image/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Image\Adapter |
 | Uses       | Phalcon\Image\Enum, Phalcon\Image\Exception |
@@ -199,7 +199,7 @@ public function watermark( AdapterInterface $watermark, int $offsetX = int, int 
         
 <h1 id="image-adapter-adapterinterface">Interface Phalcon\Image\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/image/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Image/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Image\Adapter |
 | Uses       | Phalcon\Image\Enum |
@@ -287,7 +287,7 @@ public function watermark( AdapterInterface $watermark, int $offsetX = int, int 
         
 <h1 id="image-adapter-gd">Class Phalcon\Image\Adapter\Gd</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/image/adapter/gd.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Image/Adapter/Gd.zep)
 
 | Namespace  | Phalcon\Image\Adapter |
 | Uses       | Phalcon\Image\Enum, Phalcon\Image\Exception |
@@ -408,7 +408,7 @@ protected function processWatermark( AdapterInterface $watermark, int $offsetX, 
         
 <h1 id="image-adapter-imagick">Class Phalcon\Image\Adapter\Imagick</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/image/adapter/imagick.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Image/Adapter/Imagick.zep)
 
 | Namespace  | Phalcon\Image\Adapter |
 | Uses       | Phalcon\Image\Enum, Phalcon\Image\Exception |
@@ -571,7 +571,7 @@ Execute a watermarking.
         
 <h1 id="image-enum">Class Phalcon\Image\Enum</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/image/enum.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Image/Enum.zep)
 
 | Namespace  | Phalcon\Image |
 
@@ -599,7 +599,7 @@ const WIDTH = 2;
         
 <h1 id="image-exception">Class Phalcon\Image\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/image/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Image/Exception.zep)
 
 | Namespace  | Phalcon\Image |
 | Extends    | \Phalcon\Exception |
@@ -615,7 +615,7 @@ file that was distributed with this source code.
         
 <h1 id="image-imagefactory">Class Phalcon\Image\ImageFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/image/imagefactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Image/ImageFactory.zep)
 
 | Namespace  | Phalcon\Image |
 | Uses       | Phalcon\Config, Phalcon\Factory\AbstractFactory, Phalcon\Helper\Arr, Phalcon\Image\Adapter\AdapterInterface |
@@ -634,7 +634,7 @@ TagFactory constructor.
 ```php
 public function load( mixed $config ): AdapterInterface;
 ```
-Factory to create an instace from a Config object
+Factory to create an instance from a Config object
 
 
 ```php

--- a/en/api/phalcon_kernel.md
+++ b/en/api/phalcon_kernel.md
@@ -9,7 +9,7 @@ title: 'Phalcon\Kernel'
         
 <h1 id="kernel">Class Phalcon\Kernel</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/kernel.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Kernel.zep)
 
 | Namespace  | Phalcon |
 

--- a/en/api/phalcon_loader.md
+++ b/en/api/phalcon_loader.md
@@ -10,7 +10,7 @@ title: 'Phalcon\Loader'
         
 <h1 id="loader">Class Phalcon\Loader</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/loader.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Loader.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Loader\Exception, Phalcon\Events\ManagerInterface, Phalcon\Events\EventsAwareInterface |
@@ -228,7 +228,7 @@ protected function prepareNamespace( array $namespaceName ): array;
         
 <h1 id="loader-exception">Class Phalcon\Loader\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/loader/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Loader/Exception.zep)
 
 | Namespace  | Phalcon\Loader |
 | Extends    | \Phalcon\Exception |

--- a/en/api/phalcon_logger.md
+++ b/en/api/phalcon_logger.md
@@ -22,7 +22,7 @@ title: 'Phalcon\Logger'
         
 <h1 id="logger">Class Phalcon\Logger</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Psr\Log\LoggerInterface, Phalcon\Logger\Adapter\AdapterInterface, Phalcon\Logger\Item, Phalcon\Logger\Exception |
@@ -268,7 +268,7 @@ Returns an array of log levels with integer to string conversion
         
 <h1 id="logger-adapter-abstractadapter">Abstract Class Phalcon\Logger\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Logger\Adapter |
 | Uses       | Phalcon\Logger, Phalcon\Logger\Exception, Phalcon\Logger\Formatter\FormatterInterface, Phalcon\Logger\Item |
@@ -372,7 +372,7 @@ Sets the message formatter
         
 <h1 id="logger-adapter-adapterinterface">Interface Phalcon\Logger\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Logger\Adapter |
 | Uses       | Phalcon\Logger\Formatter\FormatterInterface, Phalcon\Logger\Item |
@@ -444,7 +444,7 @@ Sets the message formatter
         
 <h1 id="logger-adapter-noop">Class Phalcon\Logger\Adapter\Noop</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/adapter/noop.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Adapter/Noop.zep)
 
 | Namespace  | Phalcon\Logger\Adapter |
 | Uses       | Phalcon\Logger\Item |
@@ -481,7 +481,7 @@ Processes the message i.e. writes it to the file
         
 <h1 id="logger-adapter-stream">Class Phalcon\Logger\Adapter\Stream</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/adapter/stream.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Adapter/Stream.zep)
 
 | Namespace  | Phalcon\Logger\Adapter |
 | Uses       | Phalcon\Logger\Adapter, Phalcon\Logger\Exception, Phalcon\Logger\Formatter\FormatterInterface, Phalcon\Logger\Item, UnexpectedValueException |
@@ -562,7 +562,7 @@ Processes the message i.e. writes it to the file
         
 <h1 id="logger-adapter-syslog">Class Phalcon\Logger\Adapter\Syslog</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/adapter/syslog.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Adapter/Syslog.zep)
 
 | Namespace  | Phalcon\Logger\Adapter |
 | Uses       | LogicException, Phalcon\Helper\Arr, Phalcon\Logger, Phalcon\Logger\Adapter, Phalcon\Logger\Exception, Phalcon\Logger\Formatter\FormatterInterface, Phalcon\Logger\Item |
@@ -645,7 +645,7 @@ Processes the message i.e. writes it to the syslog
         
 <h1 id="logger-adapterfactory">Class Phalcon\Logger\AdapterFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/adapterfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/AdapterFactory.zep)
 
 | Namespace  | Phalcon\Logger |
 | Uses       | Phalcon\Factory\AbstractFactory, Phalcon\Logger\Adapter\AdapterInterface |
@@ -681,7 +681,7 @@ protected function getAdapters(): array;
         
 <h1 id="logger-exception">Class Phalcon\Logger\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Exception.zep)
 
 | Namespace  | Phalcon\Logger |
 | Extends    | \Phalcon\Exception |
@@ -694,7 +694,7 @@ Exceptions thrown in Phalcon\Logger will use this class
         
 <h1 id="logger-formatter-abstractformatter">Abstract Class Phalcon\Logger\Formatter\AbstractFormatter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/formatter/abstractformatter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Formatter/AbstractFormatter.zep)
 
 | Namespace  | Phalcon\Logger\Formatter |
 | Uses       | DateTimeImmutable, DateTimeZone, Phalcon\Logger, Phalcon\Logger\Item |
@@ -748,7 +748,7 @@ Returns the date formatted for the logger.
         
 <h1 id="logger-formatter-formatterinterface">Interface Phalcon\Logger\Formatter\FormatterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/formatter/formatterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Formatter/FormatterInterface.zep)
 
 | Namespace  | Phalcon\Logger\Formatter |
 | Uses       | Phalcon\Logger\Item |
@@ -769,7 +769,7 @@ Applies a format to an item
         
 <h1 id="logger-formatter-json">Class Phalcon\Logger\Formatter\Json</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/formatter/json.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Formatter/Json.zep)
 
 | Namespace  | Phalcon\Logger\Formatter |
 | Uses       | Phalcon\Helper\Json, Phalcon\Logger\Item |
@@ -797,7 +797,7 @@ Applies a format to a message before sent it to the internal log
         
 <h1 id="logger-formatter-line">Class Phalcon\Logger\Formatter\Line</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/formatter/line.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Formatter/Line.zep)
 
 | Namespace  | Phalcon\Logger\Formatter |
 | Uses       | DateTime, Phalcon\Logger\Item |
@@ -846,7 +846,7 @@ public function setFormat( string $format )
         
 <h1 id="logger-item">Class Phalcon\Logger\Item</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/item.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/Item.zep)
 
 | Namespace  | Phalcon\Logger |
 
@@ -927,7 +927,7 @@ public function getType(): integer
         
 <h1 id="logger-loggerfactory">Class Phalcon\Logger\LoggerFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/logger/loggerfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Logger/LoggerFactory.zep)
 
 | Namespace  | Phalcon\Logger |
 | Uses       | Phalcon\Config, Phalcon\Helper\Arr, Phalcon\Logger |
@@ -955,7 +955,7 @@ public function __construct( AdapterFactory $factory );
 ```php
 public function load( mixed $config ): Logger;
 ```
-Factory to create an instace from a Config object
+Factory to create an instance from a Config object
 
 
 ```php

--- a/en/api/phalcon_messages.md
+++ b/en/api/phalcon_messages.md
@@ -12,7 +12,7 @@ title: 'Phalcon\Messages'
         
 <h1 id="messages-exception">Class Phalcon\Messages\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/messages/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Messages/Exception.zep)
 
 | Namespace  | Phalcon\Messages |
 | Extends    | \Phalcon\Exception |
@@ -25,7 +25,7 @@ Exceptions thrown in Phalcon\Messages\* classes will use this class
         
 <h1 id="messages-message">Class Phalcon\Messages\Message</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/messages/message.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Messages/Message.zep)
 
 | Namespace  | Phalcon\Messages |
 | Uses       | JsonSerializable |
@@ -143,7 +143,7 @@ Sets message type
         
 <h1 id="messages-messageinterface">Interface Phalcon\Messages\MessageInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/messages/messageinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Messages/MessageInterface.zep)
 
 | Namespace  | Phalcon\Messages |
 
@@ -227,7 +227,7 @@ Sets message type
         
 <h1 id="messages-messages">Class Phalcon\Messages\Messages</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/messages/messages.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Messages/Messages.zep)
 
 | Namespace  | Phalcon\Messages |
 | Uses       | ArrayAccess, Countable, Iterator, JsonSerializable |

--- a/en/api/phalcon_mvc.md
+++ b/en/api/phalcon_mvc.md
@@ -89,7 +89,7 @@ title: 'Phalcon\Mvc'
         
 <h1 id="mvc-application">Class Phalcon\Mvc\Application</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/application.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Application.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Closure, Phalcon\Application\AbstractApplication, Phalcon\Di\DiInterface, Phalcon\Http\ResponseInterface, Phalcon\Events\ManagerInterface, Phalcon\Mvc\Application\Exception, Phalcon\Mvc\Router\RouteInterface, Phalcon\Mvc\ModuleDefinitionInterface |
@@ -182,7 +182,7 @@ You can full disable the view component using this method
         
 <h1 id="mvc-application-exception">Class Phalcon\Mvc\Application\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/application/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Application/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\Application |
 | Extends    | \Phalcon\Application\Exception |
@@ -195,7 +195,7 @@ Exceptions thrown in Phalcon\Mvc\Application class will use this class
         
 <h1 id="mvc-controller">Abstract Class Phalcon\Mvc\Controller</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/controller.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Controller.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Di\Injectable |
@@ -253,7 +253,7 @@ Phalcon\Mvc\Controller constructor
         
 <h1 id="mvc-controller-bindmodelinterface">Interface Phalcon\Mvc\Controller\BindModelInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/controller/bindmodelinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Controller/BindModelInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Controller |
 
@@ -273,7 +273,7 @@ Return the model name associated with this controller
         
 <h1 id="mvc-controllerinterface">Interface Phalcon\Mvc\ControllerInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/controllerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/ControllerInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 
@@ -285,7 +285,7 @@ Interface for controller handlers
         
 <h1 id="mvc-dispatcher">Class Phalcon\Mvc\Dispatcher</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/dispatcher.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Dispatcher.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Mvc\Dispatcher\Exception, Phalcon\Events\ManagerInterface, Phalcon\Http\ResponseInterface, Phalcon\Dispatcher\AbstractDispatcher |
@@ -464,7 +464,7 @@ Throws an internal exception
         
 <h1 id="mvc-dispatcher-exception">Class Phalcon\Mvc\Dispatcher\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/dispatcher/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Dispatcher/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\Dispatcher |
 | Extends    | \Phalcon\Dispatcher\Exception |
@@ -477,7 +477,7 @@ Exceptions thrown in Phalcon\Mvc\Dispatcher will use this class
         
 <h1 id="mvc-dispatcherinterface">Interface Phalcon\Mvc\DispatcherInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/dispatcherinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/DispatcherInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Dispatcher\DispatcherInterface |
@@ -529,7 +529,7 @@ Sets the default controller name
         
 <h1 id="mvc-entityinterface">Interface Phalcon\Mvc\EntityInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/entityinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/EntityInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 
@@ -555,7 +555,7 @@ Writes an attribute value by its name
         
 <h1 id="mvc-micro">Class Phalcon\Mvc\Micro</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/micro.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Micro.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | ArrayAccess, Closure, Phalcon\Di\DiInterface, Phalcon\Di\Injectable, Phalcon\Di\FactoryDefault, Phalcon\Mvc\Micro\Exception, Phalcon\Di\ServiceInterface, Phalcon\Mvc\Micro\Collection, Phalcon\Mvc\Micro\LazyLoader, Phalcon\Http\ResponseInterface, Phalcon\Mvc\Model\BinderInterface, Phalcon\Mvc\Router\RouteInterface, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface, Phalcon\Mvc\Micro\MiddlewareInterface, Phalcon\Mvc\Micro\CollectionInterface, Throwable |
@@ -896,7 +896,7 @@ $micro->setModelBinder(
 ```php
 public function setResponseHandler( mixed $handler ): Micro;
 ```
-Appends a custom 'reponse' handler to be called insted of the default
+Appends a custom 'response' handler to be called instead of the default
 response handler
 
 
@@ -918,7 +918,7 @@ executed
         
 <h1 id="mvc-micro-collection">Class Phalcon\Mvc\Micro\Collection</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/micro/collection.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Micro/Collection.zep)
 
 | Namespace  | Phalcon\Mvc\Micro |
 | Implements | CollectionInterface |
@@ -1086,7 +1086,7 @@ Internal function to add a handler to the group.
         
 <h1 id="mvc-micro-collectioninterface">Interface Phalcon\Mvc\Micro\CollectionInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/micro/collectioninterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Micro/CollectionInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Micro |
 
@@ -1190,7 +1190,7 @@ Sets a prefix for all routes added to the collection
         
 <h1 id="mvc-micro-exception">Class Phalcon\Mvc\Micro\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/micro/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Micro/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\Micro |
 | Extends    | \Phalcon\Exception |
@@ -1201,7 +1201,7 @@ Exceptions thrown in Phalcon\Mvc\Micro will use this class
         
 <h1 id="mvc-micro-lazyloader">Class Phalcon\Mvc\Micro\LazyLoader</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/micro/lazyloader.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Micro/LazyLoader.zep)
 
 | Namespace  | Phalcon\Mvc\Micro |
 | Uses       | Phalcon\Mvc\Model\BinderInterface |
@@ -1245,7 +1245,7 @@ public function getDefinition()
         
 <h1 id="mvc-micro-middlewareinterface">Interface Phalcon\Mvc\Micro\MiddlewareInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/micro/middlewareinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Micro/MiddlewareInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Micro |
 | Uses       | Phalcon\Mvc\Micro |
@@ -1264,7 +1264,7 @@ Calls the middleware
         
 <h1 id="mvc-model">Abstract Class Phalcon\Mvc\Model</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | JsonSerializable, Phalcon\Db\Adapter\AdapterInterface, Phalcon\Db\Column, Phalcon\Db\DialectInterface, Phalcon\Db\Enum, Phalcon\Db\RawValue, Phalcon\Di\AbstractInjectionAware, Phalcon\Di, Phalcon\Di\DiInterface, Phalcon\Events\ManagerInterface, Phalcon\Helper\Arr, Phalcon\Messages\Message, Phalcon\Messages\MessageInterface, Phalcon\Mvc\Model\BehaviorInterface, Phalcon\Mvc\Model\Criteria, Phalcon\Mvc\Model\CriteriaInterface, Phalcon\Mvc\Model\Exception, Phalcon\Mvc\Model\ManagerInterface, Phalcon\Mvc\Model\MetaDataInterface, Phalcon\Mvc\Model\Query, Phalcon\Mvc\Model\Query\Builder, Phalcon\Mvc\Model\Query\BuilderInterface, Phalcon\Mvc\Model\QueryInterface, Phalcon\Mvc\Model\ResultInterface, Phalcon\Mvc\Model\Resultset, Phalcon\Mvc\Model\ResultsetInterface, Phalcon\Mvc\Model\Relation, Phalcon\Mvc\Model\RelationInterface, Phalcon\Mvc\Model\TransactionInterface, Phalcon\Mvc\Model\ValidationFailed, Phalcon\Mvc\ModelInterface, Phalcon\Validation\ValidationInterface, Serializable |
@@ -2856,7 +2856,7 @@ class Subscriptors extends Model
         
 <h1 id="mvc-model-behavior">Abstract Class Phalcon\Mvc\Model\Behavior</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/behavior.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Behavior.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Mvc\ModelInterface |
@@ -2913,7 +2913,7 @@ Checks whether the behavior must take action on certain event
         
 <h1 id="mvc-model-behavior-softdelete">Class Phalcon\Mvc\Model\Behavior\SoftDelete</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/behavior/softdelete.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Behavior/SoftDelete.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Behavior |
 | Uses       | Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\Behavior, Phalcon\Mvc\Model\Exception |
@@ -2936,7 +2936,7 @@ Listens for notifications from the models manager
         
 <h1 id="mvc-model-behavior-timestampable">Class Phalcon\Mvc\Model\Behavior\Timestampable</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/behavior/timestampable.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Behavior/Timestampable.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Behavior |
 | Uses       | Closure, Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\Behavior, Phalcon\Mvc\Model\Exception |
@@ -2959,7 +2959,7 @@ Listens for notifications from the models manager
         
 <h1 id="mvc-model-behaviorinterface">Interface Phalcon\Mvc\Model\BehaviorInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/behaviorinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/BehaviorInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Mvc\ModelInterface |
@@ -2986,7 +2986,7 @@ This method receives the notifications from the EventsManager
         
 <h1 id="mvc-model-binder">Class Phalcon\Mvc\Model\Binder</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/binder.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Binder.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Closure, Phalcon\Mvc\Controller\BindModelInterface, Phalcon\Mvc\Model\Binder\BindableInterface, Phalcon\Cache\Adapter\AdapterInterface, ReflectionFunction, ReflectionMethod |
@@ -3080,7 +3080,7 @@ Get modified params for handler using reflection
         
 <h1 id="mvc-model-binder-bindableinterface">Interface Phalcon\Mvc\Model\Binder\BindableInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/binder/bindableinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Binder/BindableInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Binder |
 
@@ -3101,7 +3101,7 @@ this class
         
 <h1 id="mvc-model-binderinterface">Interface Phalcon\Mvc\Model\BinderInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/binderinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/BinderInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface |
@@ -3140,7 +3140,7 @@ Sets cache instance
         
 <h1 id="mvc-model-criteria">Class Phalcon\Mvc\Model\Criteria</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/criteria.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Criteria.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Di, Phalcon\Db\Column, Phalcon\Di\DiInterface, Phalcon\Di\InjectionAwareInterface, Phalcon\Mvc\Model\Query\BuilderInterface |
@@ -3518,7 +3518,7 @@ Sets the conditions parameter in the criteria
         
 <h1 id="mvc-model-criteriainterface">Interface Phalcon\Mvc\Model\CriteriaInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/criteriainterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/CriteriaInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Di\DiInterface |
@@ -3783,7 +3783,7 @@ Sets the conditions parameter in the criteria
         
 <h1 id="mvc-model-exception">Class Phalcon\Mvc\Model\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Extends    | \Phalcon\Exception |
@@ -3796,7 +3796,7 @@ Exceptions thrown in Phalcon\Mvc\Model\* classes will use this class
         
 <h1 id="mvc-model-manager">Class Phalcon\Mvc\Model\Manager</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/manager.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Manager.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Mvc\ModelInterface, Phalcon\Db\Adapter\AdapterInterface, Phalcon\Mvc\Model\ResultsetInterface, Phalcon\Mvc\Model\ManagerInterface, Phalcon\Di\InjectionAwareInterface, Phalcon\Events\EventsAwareInterface, Phalcon\Mvc\Model\Query, Phalcon\Mvc\Model\QueryInterface, Phalcon\Mvc\Model\Query\Builder, Phalcon\Mvc\Model\Query\BuilderInterface, Phalcon\Mvc\Model\BehaviorInterface, Phalcon\Events\ManagerInterface |
@@ -4383,7 +4383,7 @@ Merge two arrays of find parameters
         
 <h1 id="mvc-model-managerinterface">Interface Phalcon\Mvc\Model\ManagerInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/managerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/ManagerInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Db\Adapter\AdapterInterface, Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\Query\BuilderInterface, Phalcon\Mvc\Model\QueryInterface |
@@ -4722,7 +4722,7 @@ Sets if a model must use dynamic update instead of the all-field update
         
 <h1 id="mvc-model-metadata">Abstract Class Phalcon\Mvc\Model\MetaData</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Di\DiInterface, Phalcon\Di\InjectionAwareInterface, Phalcon\Mvc\Model\MetaData\Strategy\Introspection, Phalcon\Mvc\Model\MetaData\Strategy\StrategyInterface, Phalcon\Mvc\ModelInterface |
@@ -5190,7 +5190,7 @@ Initialize the metadata for certain table
         
 <h1 id="mvc-model-metadata-apcu">Class Phalcon\Mvc\Model\MetaData\Apcu</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/apcu.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Apcu.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Mvc\Model\MetaData, Phalcon\Mvc\Model\Exception, Phalcon\Cache\AdapterFactory |
@@ -5226,7 +5226,7 @@ Phalcon\Mvc\Model\MetaData\Apcu constructor
         
 <h1 id="mvc-model-metadata-libmemcached">Class Phalcon\Mvc\Model\MetaData\Libmemcached</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/libmemcached.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Libmemcached.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Mvc\Model\Exception, Phalcon\Mvc\Model\MetaData, Phalcon\Cache\AdapterFactory |
@@ -5257,7 +5257,7 @@ Flush Memcache data and resets internal meta-data in order to regenerate it
         
 <h1 id="mvc-model-metadata-memory">Class Phalcon\Mvc\Model\MetaData\Memory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/memory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Memory.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData |
 | Uses       | Phalcon\Mvc\Model\MetaData, Phalcon\Mvc\Model\Exception |
@@ -5293,7 +5293,7 @@ Writes the meta-data to temporal memory
         
 <h1 id="mvc-model-metadata-redis">Class Phalcon\Mvc\Model\MetaData\Redis</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/redis.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Redis.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Mvc\Model\MetaData, Phalcon\Cache\AdapterFactory |
@@ -5338,7 +5338,7 @@ Flush Redis data and resets internal meta-data in order to regenerate it
         
 <h1 id="mvc-model-metadata-strategy-annotations">Class Phalcon\Mvc\Model\MetaData\Strategy\Annotations</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/strategy/annotations.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Strategy/Annotations.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData\Strategy |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Db\Column, Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\MetaData, Phalcon\Mvc\Model\Exception |
@@ -5369,7 +5369,7 @@ The meta-data is obtained by reading the column descriptions from the database i
         
 <h1 id="mvc-model-metadata-strategy-introspection">Class Phalcon\Mvc\Model\MetaData\Strategy\Introspection</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/strategy/introspection.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Strategy/Introspection.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData\Strategy |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Db\Adapter\AdapterInterface, Phalcon\Db\Column, Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\Exception, Phalcon\Mvc\Model\MetaData |
@@ -5397,7 +5397,7 @@ The meta-data is obtained by reading the column descriptions from the database i
         
 <h1 id="mvc-model-metadata-strategy-strategyinterface">Interface Phalcon\Mvc\Model\MetaData\Strategy\StrategyInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/strategy/strategyinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Strategy/StrategyInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData\Strategy |
 | Uses       | Phalcon\Mvc\ModelInterface, Phalcon\Di\DiInterface |
@@ -5429,7 +5429,7 @@ The meta-data is obtained by reading the column descriptions from the database i
         
 <h1 id="mvc-model-metadata-stream">Class Phalcon\Mvc\Model\MetaData\Stream</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadata/stream.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaData/Stream.zep)
 
 | Namespace  | Phalcon\Mvc\Model\MetaData |
 | Uses       | Phalcon\Mvc\Model\MetaData, Phalcon\Mvc\Model\Exception |
@@ -5479,7 +5479,7 @@ Writes the meta-data to files
         
 <h1 id="mvc-model-metadatainterface">Interface Phalcon\Mvc\Model\MetaDataInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/metadatainterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/MetaDataInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\MetaData\Strategy\StrategyInterface |
@@ -5668,7 +5668,7 @@ Writes meta-data for certain model using a MODEL_* constant
         
 <h1 id="mvc-model-query">Class Phalcon\Mvc\Model\Query</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/query.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Query.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Db\Column, Phalcon\Db\RawValue, Phalcon\Db\ResultInterface, Phalcon\Db\Adapter\AdapterInterface, Phalcon\Di\DiInterface, Phalcon\Helper\Arr, Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\Query\Status, Phalcon\Mvc\Model\Resultset\Complex, Phalcon\Mvc\Model\Query\StatusInterface, Phalcon\Mvc\Model\ResultsetInterface, Phalcon\Mvc\Model\Resultset\Simple, Phalcon\Di\InjectionAwareInterface, Phalcon\Db\DialectInterface, Phalcon\Mvc\Model\Query\Lang |
@@ -6141,7 +6141,7 @@ inside the query object
         
 <h1 id="mvc-model-query-builder">Class Phalcon\Mvc\Model\Query\Builder</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/query/builder.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Query/Builder.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Query |
 | Uses       | Phalcon\Di, Phalcon\Db\Column, Phalcon\Di\DiInterface, Phalcon\Helper\Arr, Phalcon\Mvc\Model\Exception, Phalcon\Di\InjectionAwareInterface, Phalcon\Mvc\Model\QueryInterface |
@@ -6820,7 +6820,7 @@ Appends a NOT IN condition
         
 <h1 id="mvc-model-query-builderinterface">Interface Phalcon\Mvc\Model\Query\BuilderInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/query/builderinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Query/BuilderInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Query |
 | Uses       | Phalcon\Mvc\Model\QueryInterface |
@@ -7096,7 +7096,7 @@ Sets conditions for the query
         
 <h1 id="mvc-model-query-lang">Abstract Class Phalcon\Mvc\Model\Query\Lang</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/query/lang.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Query/Lang.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Query |
 
@@ -7132,7 +7132,7 @@ Parses a PHQL statement returning an intermediate representation (IR)
         
 <h1 id="mvc-model-query-status">Class Phalcon\Mvc\Model\Query\Status</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/query/status.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Query/Status.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Query |
 | Uses       | Phalcon\Messages\MessageInterface, Phalcon\Mvc\ModelInterface |
@@ -7204,7 +7204,7 @@ Allows to check if the executed operation was successful
         
 <h1 id="mvc-model-query-statusinterface">Interface Phalcon\Mvc\Model\Query\StatusInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/query/statusinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Query/StatusInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Query |
 | Uses       | Phalcon\Messages\MessageInterface, Phalcon\Mvc\ModelInterface |
@@ -7237,7 +7237,7 @@ Allows to check if the executed operation was successful
         
 <h1 id="mvc-model-queryinterface">Interface Phalcon\Mvc\Model\QueryInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/queryinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/QueryInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Mvc\ModelInterface |
@@ -7333,7 +7333,7 @@ Tells to the query if only the first row in the resultset must be returned
         
 <h1 id="mvc-model-relation">Class Phalcon\Mvc\Model\Relation</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/relation.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Relation.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Implements | RelationInterface |
@@ -7499,7 +7499,7 @@ Sets the intermediate model data for has-*-through relations
         
 <h1 id="mvc-model-relationinterface">Interface Phalcon\Mvc\Model\RelationInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/relationinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/RelationInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 
@@ -7609,7 +7609,7 @@ Check whether the relation is a 'many-to-many' relation or not
 ```php
 public function setIntermediateRelation( mixed $intermediateFields, string $intermediateModel, mixed $intermediateReferencedFields );
 ```
-Sets the intermediate model dat for has-*-through relations
+Sets the intermediate model data for has-*-through relations
 
 
 
@@ -7617,7 +7617,7 @@ Sets the intermediate model dat for has-*-through relations
         
 <h1 id="mvc-model-resultinterface">Interface Phalcon\Mvc\Model\ResultInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/resultinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/ResultInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Mvc\ModelInterface |
@@ -7638,7 +7638,7 @@ Sets the object's state
         
 <h1 id="mvc-model-resultset">Abstract Class Phalcon\Mvc\Model\Resultset</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/resultset.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Resultset.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | ArrayAccess, Closure, Countable, Iterator, JsonSerializable, Phalcon\Db\Enum, Phalcon\Messages\MessageInterface, Phalcon\Mvc\Model, Phalcon\Mvc\ModelInterface, Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Storage\Serializer\SerializerInterface, SeekableIterator, Serializable |
@@ -7900,7 +7900,7 @@ Check whether internal resource has rows to fetch
         
 <h1 id="mvc-model-resultset-complex">Class Phalcon\Mvc\Model\Resultset\Complex</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/resultset/complex.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Resultset/Complex.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Resultset |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Di, Phalcon\Di\DiInterface, Phalcon\Db\ResultInterface, Phalcon\Mvc\Model, Phalcon\Mvc\Model\Exception, Phalcon\Mvc\Model\Resultset, Phalcon\Mvc\Model\ResultsetInterface, Phalcon\Mvc\Model\Row, Phalcon\Mvc\ModelInterface, Phalcon\Storage\Serializer\SerializerInterface, stdClass |
@@ -7963,7 +7963,7 @@ Unserializing a resultset will allow to only works on the rows present in the sa
         
 <h1 id="mvc-model-resultset-simple">Class Phalcon\Mvc\Model\Resultset\Simple</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/resultset/simple.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Resultset/Simple.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Resultset |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface, Phalcon\Di, Phalcon\Di\DiInterface, Phalcon\Mvc\Model, Phalcon\Mvc\Model\Exception, Phalcon\Mvc\Model\Resultset, Phalcon\Mvc\Model\Row, Phalcon\Mvc\ModelInterface, Phalcon\Storage\Serializer\SerializerInterface |
@@ -8030,7 +8030,7 @@ the saved state
         
 <h1 id="mvc-model-resultsetinterface">Interface Phalcon\Mvc\Model\ResultsetInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/resultsetinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/ResultsetInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Closure, Phalcon\Messages\MessageInterface, Phalcon\Mvc\ModelInterface, Phalcon\Cache\Adapter\AdapterInterface |
@@ -8135,7 +8135,7 @@ Updates every record in the resultset
         
 <h1 id="mvc-model-row">Class Phalcon\Mvc\Model\Row</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/row.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Row.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | ArrayAccess, JsonSerializable, Phalcon\Mvc\EntityInterface, Phalcon\Mvc\ModelInterface |
@@ -8223,7 +8223,7 @@ $robot->writeAttribute("name", "Rosey");
         
 <h1 id="mvc-model-transaction">Class Phalcon\Mvc\Model\Transaction</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/transaction.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Transaction.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\Transaction\Failed, Phalcon\Mvc\Model\Transaction\ManagerInterface, Phalcon\Mvc\Model\TransactionInterface |
@@ -8384,7 +8384,7 @@ Enables throwing exception
         
 <h1 id="mvc-model-transaction-exception">Class Phalcon\Mvc\Model\Transaction\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/transaction/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Transaction/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Transaction |
 | Extends    | \Phalcon\Mvc\Model\Exception |
@@ -8397,7 +8397,7 @@ Exceptions thrown in Phalcon\Mvc\Model\Transaction will use this class
         
 <h1 id="mvc-model-transaction-failed">Class Phalcon\Mvc\Model\Transaction\Failed</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/transaction/failed.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Transaction/Failed.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Transaction |
 | Uses       | Phalcon\Messages\MessageInterface, Phalcon\Mvc\ModelInterface |
@@ -8438,7 +8438,7 @@ Returns validation record messages which stop the transaction
         
 <h1 id="mvc-model-transaction-manager">Class Phalcon\Mvc\Model\Transaction\Manager</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/transaction/manager.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Transaction/Manager.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Transaction |
 | Uses       | Phalcon\Di, Phalcon\Di\DiInterface, Phalcon\Di\InjectionAwareInterface, Phalcon\Mvc\Model\Transaction, Phalcon\Mvc\Model\TransactionInterface |
@@ -8626,7 +8626,7 @@ Removes transactions from the TransactionManager
         
 <h1 id="mvc-model-transaction-managerinterface">Interface Phalcon\Mvc\Model\Transaction\ManagerInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/transaction/managerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/Transaction/ManagerInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model\Transaction |
 | Uses       | Phalcon\Mvc\Model\TransactionInterface |
@@ -8714,7 +8714,7 @@ Set if the transaction manager must register a shutdown function to clean up pen
         
 <h1 id="mvc-model-transactioninterface">Interface Phalcon\Mvc\Model\TransactionInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/transactioninterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/TransactionInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\Transaction\ManagerInterface |
@@ -8801,7 +8801,7 @@ Enables throwing exception
         
 <h1 id="mvc-model-validationfailed">Class Phalcon\Mvc\Model\ValidationFailed</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/model/validationfailed.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Model/ValidationFailed.zep)
 
 | Namespace  | Phalcon\Mvc\Model |
 | Uses       | Phalcon\Mvc\ModelInterface |
@@ -8847,7 +8847,7 @@ Returns the model that generated the messages
         
 <h1 id="mvc-modelinterface">Interface Phalcon\Mvc\ModelInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/modelinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/ModelInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Db\Adapter\AdapterInterface, Phalcon\Di\DiInterface, Phalcon\Messages\MessageInterface, Phalcon\Mvc\Model\CriteriaInterface, Phalcon\Mvc\Model\MetaDataInterface, Phalcon\Mvc\Model\ResultsetInterface, Phalcon\Mvc\Model\TransactionInterface |
@@ -9129,7 +9129,7 @@ Check whether validation process has generated any messages
         
 <h1 id="mvc-moduledefinitioninterface">Interface Phalcon\Mvc\ModuleDefinitionInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/moduledefinitioninterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/ModuleDefinitionInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Di\DiInterface |
@@ -9156,7 +9156,7 @@ Registers services related to the module
         
 <h1 id="mvc-router">Class Phalcon\Mvc\Router</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/router.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Router.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface, Phalcon\Http\RequestInterface, Phalcon\Mvc\Router\Exception, Phalcon\Mvc\Router\GroupInterface, Phalcon\Mvc\Router\Route, Phalcon\Mvc\Router\RouteInterface |
@@ -9567,7 +9567,7 @@ Checks if the router matches any of the defined routes
         
 <h1 id="mvc-router-annotations">Class Phalcon\Mvc\Router\Annotations</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/router/annotations.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Router/Annotations.zep)
 
 | Namespace  | Phalcon\Mvc\Router |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Mvc\Router, Phalcon\Annotations\Annotation |
@@ -9667,7 +9667,7 @@ Changes the controller class suffix
         
 <h1 id="mvc-router-exception">Class Phalcon\Mvc\Router\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/router/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Router/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\Router |
 | Extends    | \Phalcon\Exception |
@@ -9680,7 +9680,7 @@ Exceptions thrown in Phalcon\Mvc\Router will use this class
         
 <h1 id="mvc-router-group">Class Phalcon\Mvc\Router\Group</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/router/group.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Router/Group.zep)
 
 | Namespace  | Phalcon\Mvc\Router |
 | Implements | GroupInterface |
@@ -9911,7 +9911,7 @@ Adds a route applying the common attributes
         
 <h1 id="mvc-router-groupinterface">Interface Phalcon\Mvc\Router\GroupInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/router/groupinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Router/GroupInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Router |
 
@@ -10099,7 +10099,7 @@ Set a common uri prefix for all the routes in this group
         
 <h1 id="mvc-router-route">Class Phalcon\Mvc\Router\Route</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/router/route.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Router/Route.zep)
 
 | Namespace  | Phalcon\Mvc\Router |
 | Implements | RouteInterface |
@@ -10382,7 +10382,7 @@ $route->via(
         
 <h1 id="mvc-router-routeinterface">Interface Phalcon\Mvc\Router\RouteInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/router/routeinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/Router/RouteInterface.zep)
 
 | Namespace  | Phalcon\Mvc\Router |
 
@@ -10492,7 +10492,7 @@ Set one or more HTTP methods that constraint the matching of the route
         
 <h1 id="mvc-routerinterface">Interface Phalcon\Mvc\RouterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/routerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/RouterInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Mvc\Router\RouteInterface, Phalcon\Mvc\Router\GroupInterface |
@@ -10686,7 +10686,7 @@ Check if the router matches any of the defined routes
         
 <h1 id="mvc-view">Class Phalcon\Mvc\View</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Closure, Phalcon\Di\DiInterface, Phalcon\Di\Injectable, Phalcon\Events\ManagerInterface, Phalcon\Helper\Arr, Phalcon\Helper\Str, Phalcon\Mvc\View\Exception, Phalcon\Events\EventsAwareInterface, Phalcon\Mvc\View\Engine\Php |
@@ -11287,7 +11287,7 @@ Phalcon\Mvc\View\Engine\Php
         
 <h1 id="mvc-view-engine-abstractengine">Abstract Class Phalcon\Mvc\View\Engine\AbstractEngine</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/engine/abstractengine.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Engine/AbstractEngine.zep)
 
 | Namespace  | Phalcon\Mvc\View\Engine |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\Injectable, Phalcon\Mvc\ViewBaseInterface |
@@ -11335,7 +11335,7 @@ Renders a partial inside another view
         
 <h1 id="mvc-view-engine-engineinterface">Interface Phalcon\Mvc\View\Engine\EngineInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/engine/engineinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Engine/EngineInterface.zep)
 
 | Namespace  | Phalcon\Mvc\View\Engine |
 
@@ -11365,7 +11365,7 @@ Renders a view using the template engine
         
 <h1 id="mvc-view-engine-php">Class Phalcon\Mvc\View\Engine\Php</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/engine/php.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Engine/Php.zep)
 
 | Namespace  | Phalcon\Mvc\View\Engine |
 | Extends    | AbstractEngine |
@@ -11384,7 +11384,7 @@ Renders a view using the template engine
         
 <h1 id="mvc-view-engine-volt">Class Phalcon\Mvc\View\Engine\Volt</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/engine/volt.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Engine/Volt.zep)
 
 | Namespace  | Phalcon\Mvc\View\Engine |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface, Phalcon\Mvc\View\Engine\Volt\Compiler, Phalcon\Mvc\View\Exception |
@@ -11487,7 +11487,7 @@ Sorts an array
         
 <h1 id="mvc-view-engine-volt-compiler">Class Phalcon\Mvc\View\Engine\Volt\Compiler</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/engine/volt/compiler.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Engine/Volt/Compiler.zep)
 
 | Namespace  | Phalcon\Mvc\View\Engine\Volt |
 | Uses       | Closure, Phalcon\Di\DiInterface, Phalcon\Mvc\ViewBaseInterface, Phalcon\Di\InjectionAwareInterface |
@@ -11888,7 +11888,7 @@ Compiles a block of statements
         
 <h1 id="mvc-view-engine-volt-exception">Class Phalcon\Mvc\View\Engine\Volt\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/engine/volt/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Engine/Volt/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\View\Engine\Volt |
 | Uses       | Phalcon\Mvc\View\Exception |
@@ -11920,7 +11920,7 @@ Gets currently parsed statement (if any).
         
 <h1 id="mvc-view-exception">Class Phalcon\Mvc\View\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Exception.zep)
 
 | Namespace  | Phalcon\Mvc\View |
 | Extends    | \Phalcon\Exception |
@@ -11933,7 +11933,7 @@ Class for exceptions thrown by Phalcon\Mvc\View
         
 <h1 id="mvc-view-simple">Class Phalcon\Mvc\View\Simple</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/view/simple.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/View/Simple.zep)
 
 | Namespace  | Phalcon\Mvc\View |
 | Uses       | Closure, Phalcon\Di\DiInterface, Phalcon\Di\Injectable, Phalcon\Events\EventsAwareInterface, Phalcon\Events\ManagerInterface, Phalcon\Helper\Arr, Phalcon\Helper\Str, Phalcon\Mvc\ViewBaseInterface, Phalcon\Mvc\View\Engine\EngineInterface, Phalcon\Mvc\View\Engine\Php |
@@ -12187,7 +12187,7 @@ Phalcon\Mvc\View\Engine\Php
         
 <h1 id="mvc-viewbaseinterface">Interface Phalcon\Mvc\ViewBaseInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/viewbaseinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/ViewBaseInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Uses       | Phalcon\Cache\Adapter\AdapterInterface |
@@ -12251,7 +12251,7 @@ slash or backslash
         
 <h1 id="mvc-viewinterface">Interface Phalcon\Mvc\ViewInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/mvc/viewinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Mvc/ViewInterface.zep)
 
 | Namespace  | Phalcon\Mvc |
 | Extends    | ViewBaseInterface |

--- a/en/api/phalcon_paginator.md
+++ b/en/api/phalcon_paginator.md
@@ -17,7 +17,7 @@ title: 'Phalcon\Paginator'
         
 <h1 id="paginator-adapter-abstractadapter">Abstract Class Phalcon\Paginator\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Paginator\Adapter |
 | Uses       | Phalcon\Paginator\Exception, Phalcon\Paginator\Repository, Phalcon\Paginator\RepositoryInterface |
@@ -93,7 +93,7 @@ Gets current repository for pagination
         
 <h1 id="paginator-adapter-adapterinterface">Interface Phalcon\Paginator\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Paginator\Adapter |
 | Uses       | Phalcon\Paginator\RepositoryInterface |
@@ -132,7 +132,7 @@ Set current rows limit
         
 <h1 id="paginator-adapter-model">Class Phalcon\Paginator\Adapter\Model</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/adapter/model.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/Adapter/Model.zep)
 
 | Namespace  | Phalcon\Paginator\Adapter |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Mvc\ModelInterface, Phalcon\Mvc\Model\ResultsetInterface, Phalcon\Paginator\Exception, Phalcon\Paginator\RepositoryInterface |
@@ -216,7 +216,7 @@ Returns a slice of the resultset to show in the pagination
         
 <h1 id="paginator-adapter-nativearray">Class Phalcon\Paginator\Adapter\NativeArray</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/adapter/nativearray.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/Adapter/NativeArray.zep)
 
 | Namespace  | Phalcon\Paginator\Adapter |
 | Uses       | Phalcon\Paginator\Exception, Phalcon\Paginator\RepositoryInterface |
@@ -256,7 +256,7 @@ Returns a slice of the resultset to show in the pagination
         
 <h1 id="paginator-adapter-querybuilder">Class Phalcon\Paginator\Adapter\QueryBuilder</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/adapter/querybuilder.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/Adapter/QueryBuilder.zep)
 
 | Namespace  | Phalcon\Paginator\Adapter |
 | Uses       | Phalcon\Db\Enum, Phalcon\Mvc\Model\Query\Builder, Phalcon\Paginator\RepositoryInterface, Phalcon\Paginator\Exception |
@@ -333,7 +333,7 @@ Set query builder object
         
 <h1 id="paginator-exception">Class Phalcon\Paginator\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/Exception.zep)
 
 | Namespace  | Phalcon\Paginator |
 | Extends    | \Phalcon\Exception |
@@ -346,7 +346,7 @@ Exceptions thrown in Phalcon\Paginator will use this class
         
 <h1 id="paginator-paginatorfactory">Class Phalcon\Paginator\PaginatorFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/paginatorfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/PaginatorFactory.zep)
 
 | Namespace  | Phalcon\Paginator |
 | Uses       | Phalcon\Paginator\Adapter\AdapterInterface, Phalcon\Factory\AbstractFactory, Phalcon\Helper\Arr |
@@ -370,7 +370,7 @@ AdapterFactory constructor.
 ```php
 public function load( mixed $config ): AdapterInterface;
 ```
-Factory to create an instace from a Config object
+Factory to create an instance from a Config object
 
 ```php
 use Phalcon\Paginator\PaginatorFactory;
@@ -408,7 +408,7 @@ protected function getAdapters(): array;
         
 <h1 id="paginator-repository">Class Phalcon\Paginator\Repository</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/repository.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/Repository.zep)
 
 | Namespace  | Phalcon\Paginator |
 | Uses       | JsonSerializable, Phalcon\Helper\Arr |
@@ -528,7 +528,7 @@ Resolve alias property name
         
 <h1 id="paginator-repositoryinterface">Interface Phalcon\Paginator\RepositoryInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/paginator/repositoryinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Paginator/RepositoryInterface.zep)
 
 | Namespace  | Phalcon\Paginator |
 

--- a/en/api/phalcon_registry.md
+++ b/en/api/phalcon_registry.md
@@ -9,7 +9,7 @@ title: 'Phalcon\Registry'
         
 <h1 id="registry">Final Class Phalcon\Registry</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/registry.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Registry.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Traversable |

--- a/en/api/phalcon_security.md
+++ b/en/api/phalcon_security.md
@@ -11,7 +11,7 @@ title: 'Phalcon\Security'
         
 <h1 id="security">Class Phalcon\Security</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/security.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Security.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Http\RequestInterface, Phalcon\Security\Random, Phalcon\Security\Exception, Phalcon\Session\ManagerInterface |
@@ -232,7 +232,7 @@ Sets the work factor
         
 <h1 id="security-exception">Class Phalcon\Security\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/security/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Security/Exception.zep)
 
 | Namespace  | Phalcon\Security |
 | Extends    | \Phalcon\Exception |
@@ -245,7 +245,7 @@ Exceptions thrown in Phalcon\Security will use this class
         
 <h1 id="security-random">Class Phalcon\Security\Random</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/security/random.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Security/Random.zep)
 
 | Namespace  | Phalcon\Security |
 

--- a/en/api/phalcon_session.md
+++ b/en/api/phalcon_session.md
@@ -17,7 +17,7 @@ title: 'Phalcon\Session'
         
 <h1 id="session-adapter-abstractadapter">Abstract Class Phalcon\Session\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Session\Adapter |
 | Uses       | Phalcon\Storage\Adapter\AdapterInterface, SessionHandlerInterface |
@@ -81,7 +81,7 @@ Write
         
 <h1 id="session-adapter-libmemcached">Class Phalcon\Session\Adapter\Libmemcached</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/adapter/libmemcached.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Adapter/Libmemcached.zep)
 
 | Namespace  | Phalcon\Session\Adapter |
 | Uses       | Phalcon\Storage\AdapterFactory |
@@ -101,7 +101,7 @@ Constructor
         
 <h1 id="session-adapter-noop">Class Phalcon\Session\Adapter\Noop</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/adapter/noop.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Adapter/Noop.zep)
 
 | Namespace  | Phalcon\Session\Adapter |
 | Uses       | SessionHandlerInterface |
@@ -206,7 +206,7 @@ Helper method to get the name prefixed
         
 <h1 id="session-adapter-redis">Class Phalcon\Session\Adapter\Redis</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/adapter/redis.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Adapter/Redis.zep)
 
 | Namespace  | Phalcon\Session\Adapter |
 | Uses       | Phalcon\Storage\AdapterFactory |
@@ -226,7 +226,7 @@ Constructor
         
 <h1 id="session-adapter-stream">Class Phalcon\Session\Adapter\Stream</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/adapter/stream.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Adapter/Stream.zep)
 
 | Namespace  | Phalcon\Session\Adapter |
 | Uses       | Phalcon\Helper\Str, Phalcon\Session\Exception |
@@ -299,7 +299,7 @@ public function write( mixed $id, mixed $data ): bool;
         
 <h1 id="session-bag">Class Phalcon\Session\Bag</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/bag.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Bag.zep)
 
 | Namespace  | Phalcon\Session |
 | Uses       | Phalcon\Collection, Phalcon\Di, Phalcon\Di\DiInterface, Phalcon\Di\InjectionAwareInterface |
@@ -380,7 +380,7 @@ Sets the DependencyInjector container
         
 <h1 id="session-exception">Class Phalcon\Session\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Exception.zep)
 
 | Namespace  | Phalcon\Session |
 | Extends    | \Phalcon\Exception |
@@ -393,7 +393,7 @@ Exceptions thrown in Phalcon\Session will use this class
         
 <h1 id="session-manager">Class Phalcon\Session\Manager</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/manager.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/Manager.zep)
 
 | Namespace  | Phalcon\Session |
 | Uses       | InvalidArgumentException, RuntimeException, SessionHandlerInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Di\DiInterface, Phalcon\Helper\Arr |
@@ -573,7 +573,7 @@ Returns the status of the current session.
         
 <h1 id="session-managerinterface">Interface Phalcon\Session\ManagerInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/session/managerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Session/ManagerInterface.zep)
 
 | Namespace  | Phalcon\Session |
 | Uses       | InvalidArgumentException, RuntimeException, SessionHandlerInterface |

--- a/en/api/phalcon_storage.md
+++ b/en/api/phalcon_storage.md
@@ -26,7 +26,7 @@ title: 'Phalcon\Storage'
         
 <h1 id="storage-adapter-abstractadapter">Abstract Class Phalcon\Storage\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Storage\Adapter |
 | Uses       | DateInterval, DateTime, Phalcon\Helper\Arr, Phalcon\Helper\Str, Phalcon\Storage\Exception, Phalcon\Storage\SerializerFactory, Phalcon\Storage\Serializer\SerializerInterface |
@@ -205,7 +205,7 @@ Initializes the serializer
         
 <h1 id="storage-adapter-adapterinterface">Interface Phalcon\Storage\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Storage\Adapter |
 | Uses       | Phalcon\Storage\Serializer\SerializerInterface |
@@ -279,7 +279,7 @@ Stores data in the adapter
         
 <h1 id="storage-adapter-apcu">Class Phalcon\Storage\Adapter\Apcu</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapter/apcu.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Adapter/Apcu.zep)
 
 | Namespace  | Phalcon\Storage\Adapter |
 | Uses       | APCuIterator, Phalcon\Helper\Arr, Phalcon\Storage\Exception, Phalcon\Storage\SerializerFactory, Phalcon\Storage\Serializer\SerializerInterface |
@@ -385,7 +385,7 @@ Stores data in the adapter
         
 <h1 id="storage-adapter-libmemcached">Class Phalcon\Storage\Adapter\Libmemcached</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapter/libmemcached.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Adapter/Libmemcached.zep)
 
 | Namespace  | Phalcon\Storage\Adapter |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Storage\Exception, Phalcon\Storage\SerializerFactory, Phalcon\Storage\Serializer\SerializerInterface |
@@ -498,7 +498,7 @@ Stores data in the adapter
         
 <h1 id="storage-adapter-memory">Class Phalcon\Storage\Adapter\Memory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapter/memory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Adapter/Memory.zep)
 
 | Namespace  | Phalcon\Storage\Adapter |
 | Uses       | Phalcon\Collection, Phalcon\Helper\Arr, Phalcon\Storage\Exception, Phalcon\Storage\SerializerFactory, Phalcon\Storage\Serializer\SerializerInterface |
@@ -608,7 +608,7 @@ Stores data in the adapter
         
 <h1 id="storage-adapter-redis">Class Phalcon\Storage\Adapter\Redis</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapter/redis.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Adapter/Redis.zep)
 
 | Namespace  | Phalcon\Storage\Adapter |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Storage\Exception, Phalcon\Storage\SerializerFactory, Phalcon\Storage\Serializer\SerializerInterface |
@@ -726,7 +726,7 @@ Stores data in the adapter
         
 <h1 id="storage-adapter-stream">Class Phalcon\Storage\Adapter\Stream</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapter/stream.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Adapter/Stream.zep)
 
 | Namespace  | Phalcon\Storage\Adapter |
 | Uses       | FilesystemIterator, Iterator, Phalcon\Helper\Arr, Phalcon\Helper\Str, Phalcon\Storage\Exception, Phalcon\Storage\SerializerFactory, Phalcon\Storage\Serializer\SerializerInterface, RecursiveDirectoryIterator, RecursiveIteratorIterator |
@@ -840,7 +840,7 @@ Stores data in the adapter
         
 <h1 id="storage-adapterfactory">Class Phalcon\Storage\AdapterFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/adapterfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/AdapterFactory.zep)
 
 | Namespace  | Phalcon\Storage |
 | Uses       | Phalcon\Factory\AbstractFactory, Phalcon\Storage\Adapter\AdapterInterface |
@@ -885,7 +885,7 @@ protected function getAdapters(): array;
         
 <h1 id="storage-exception">Class Phalcon\Storage\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Exception.zep)
 
 | Namespace  | Phalcon\Storage |
 | Extends    | \Phalcon\Exception |
@@ -899,7 +899,7 @@ Exceptions thrown in Phalcon\Storage will use this class
         
 <h1 id="storage-serializer-abstractserializer">Abstract Class Phalcon\Storage\Serializer\AbstractSerializer</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/abstractserializer.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/AbstractSerializer.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Uses       | Phalcon\Storage\Exception |
@@ -950,7 +950,7 @@ If this returns true, then the data returns back as is
         
 <h1 id="storage-serializer-base64">Class Phalcon\Storage\Serializer\Base64</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/base64.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/Base64.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Uses       | InvalidArgumentException |
@@ -981,7 +981,7 @@ public function unserialize( mixed $data ): void;
         
 <h1 id="storage-serializer-igbinary">Class Phalcon\Storage\Serializer\Igbinary</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/igbinary.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/Igbinary.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Extends    | AbstractSerializer |
@@ -1011,7 +1011,7 @@ public function unserialize( mixed $data ): void;
         
 <h1 id="storage-serializer-json">Class Phalcon\Storage\Serializer\Json</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/json.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/Json.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Uses       | InvalidArgumentException, JsonSerializable, Phalcon\Helper\Json |
@@ -1042,7 +1042,7 @@ public function unserialize( mixed $data ): void;
         
 <h1 id="storage-serializer-msgpack">Class Phalcon\Storage\Serializer\Msgpack</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/msgpack.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/Msgpack.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Extends    | AbstractSerializer |
@@ -1072,7 +1072,7 @@ public function unserialize( mixed $data ): void;
         
 <h1 id="storage-serializer-none">Class Phalcon\Storage\Serializer\None</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/none.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/None.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Uses       | InvalidArgumentException |
@@ -1103,7 +1103,7 @@ public function unserialize( mixed $data ): void;
         
 <h1 id="storage-serializer-php">Class Phalcon\Storage\Serializer\Php</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/php.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/Php.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Uses       | InvalidArgumentException, Phalcon\Storage\Exception |
@@ -1134,7 +1134,7 @@ public function unserialize( mixed $data ): void;
         
 <h1 id="storage-serializer-serializerinterface">Interface Phalcon\Storage\Serializer\SerializerInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializer/serializerinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/Serializer/SerializerInterface.zep)
 
 | Namespace  | Phalcon\Storage\Serializer |
 | Uses       | Serializable |
@@ -1164,7 +1164,7 @@ public function setData( mixed $data ): void;
         
 <h1 id="storage-serializerfactory">Class Phalcon\Storage\SerializerFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/storage/serializerfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Storage/SerializerFactory.zep)
 
 | Namespace  | Phalcon\Storage |
 | Uses       | Phalcon\Factory\AbstractFactory, Phalcon\Storage\Serializer\SerializerInterface |

--- a/en/api/phalcon_tag.md
+++ b/en/api/phalcon_tag.md
@@ -11,7 +11,7 @@ title: 'Phalcon\Tag'
         
 <h1 id="tag">Class Phalcon\Tag</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/tag.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Tag.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Escaper\EscaperInterface, Phalcon\Tag\Select, Phalcon\Tag\Exception, Phalcon\Url\UrlInterface |
@@ -280,7 +280,7 @@ Renders parameters keeping order in their HTML attributes
 ```php
 public static function renderTitle( bool $prepend = bool, bool $append = bool ): string;
 ```
-Renders the title with title tags. The title is automaticall escaped
+Renders the title with title tags. The title is automatically escaped
 
 
 ```php
@@ -428,7 +428,7 @@ Builds INPUT tags that implements the checked attribute
         
 <h1 id="tag-exception">Class Phalcon\Tag\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/tag/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Tag/Exception.zep)
 
 | Namespace  | Phalcon\Tag |
 | Extends    | \Phalcon\Exception |
@@ -441,7 +441,7 @@ Exceptions thrown in Phalcon\Tag will use this class
         
 <h1 id="tag-select">Abstract Class Phalcon\Tag\Select</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/tag/select.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Tag/Select.zep)
 
 | Namespace  | Phalcon\Tag |
 | Uses       | Phalcon\Tag, Phalcon\Escaper\EscaperInterface, Phalcon\Mvc\Model\ResultsetInterface |

--- a/en/api/phalcon_text.md
+++ b/en/api/phalcon_text.md
@@ -9,7 +9,7 @@ title: 'Phalcon\Text'
         
 <h1 id="text">Class Phalcon\Text</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/text.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Text.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Helper\Str |

--- a/en/api/phalcon_translate.md
+++ b/en/api/phalcon_translate.md
@@ -19,7 +19,7 @@ title: 'Phalcon\Translate'
         
 <h1 id="translate-adapter-abstractadapter">Abstract Class Phalcon\Translate\Adapter\AbstractAdapter</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/adapter/abstractadapter.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Adapter/AbstractAdapter.zep)
 
 | Namespace  | Phalcon\Translate\Adapter |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Translate\Exception, Phalcon\Translate\InterpolatorFactory |
@@ -99,7 +99,7 @@ Replaces placeholders by the values passed
         
 <h1 id="translate-adapter-adapterinterface">Interface Phalcon\Translate\Adapter\AdapterInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/adapter/adapterinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Adapter/AdapterInterface.zep)
 
 | Namespace  | Phalcon\Translate\Adapter |
 
@@ -133,7 +133,7 @@ Returns the translation string of the given key
         
 <h1 id="translate-adapter-csv">Class Phalcon\Translate\Adapter\Csv</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/adapter/csv.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Adapter/Csv.zep)
 
 | Namespace  | Phalcon\Translate\Adapter |
 | Uses       | ArrayAccess, Phalcon\Translate\Exception, Phalcon\Translate\InterpolatorFactory |
@@ -177,7 +177,7 @@ Returns the translation related to the given key
         
 <h1 id="translate-adapter-gettext">Class Phalcon\Translate\Adapter\Gettext</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/adapter/gettext.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Adapter/Gettext.zep)
 
 | Namespace  | Phalcon\Translate\Adapter |
 | Uses       | ArrayAccess, Phalcon\Translate\Exception, Phalcon\Translate\InterpolatorFactory |
@@ -346,7 +346,7 @@ Validator for constructor
         
 <h1 id="translate-adapter-nativearray">Class Phalcon\Translate\Adapter\NativeArray</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/adapter/nativearray.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Adapter/NativeArray.zep)
 
 | Namespace  | Phalcon\Translate\Adapter |
 | Uses       | ArrayAccess, Phalcon\Translate\Exception, Phalcon\Translate\InterpolatorFactory |
@@ -388,7 +388,7 @@ Check whether is defined a translation key in the internal array
 ```php
 public function notFound( string $index ): string;
 ```
-Whenever a key is not found this medhod will be called
+Whenever a key is not found this method will be called
 
 
 ```php
@@ -401,7 +401,7 @@ Returns the translation related to the given key
         
 <h1 id="translate-exception">Class Phalcon\Translate\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Exception.zep)
 
 | Namespace  | Phalcon\Translate |
 | Extends    | \Phalcon\Exception |
@@ -414,7 +414,7 @@ Class for exceptions thrown by Phalcon\Translate
         
 <h1 id="translate-interpolator-associativearray">Class Phalcon\Translate\Interpolator\AssociativeArray</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/interpolator/associativearray.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Interpolator/AssociativeArray.zep)
 
 | Namespace  | Phalcon\Translate\Interpolator |
 | Implements | InterpolatorInterface |
@@ -438,7 +438,7 @@ Replaces placeholders by the values passed
         
 <h1 id="translate-interpolator-indexedarray">Class Phalcon\Translate\Interpolator\IndexedArray</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/interpolator/indexedarray.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Interpolator/IndexedArray.zep)
 
 | Namespace  | Phalcon\Translate\Interpolator |
 | Implements | InterpolatorInterface |
@@ -462,7 +462,7 @@ Replaces placeholders by the values passed
         
 <h1 id="translate-interpolator-interpolatorinterface">Interface Phalcon\Translate\Interpolator\InterpolatorInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/interpolator/interpolatorinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/Interpolator/InterpolatorInterface.zep)
 
 | Namespace  | Phalcon\Translate\Interpolator |
 
@@ -482,7 +482,7 @@ Replaces placeholders by the values passed
         
 <h1 id="translate-interpolatorfactory">Class Phalcon\Translate\InterpolatorFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/interpolatorfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/InterpolatorFactory.zep)
 
 | Namespace  | Phalcon\Translate |
 | Uses       | Phalcon\Factory\AbstractFactory, Phalcon\Translate\Adapter\AdapterInterface |
@@ -532,7 +532,7 @@ protected function getAdapters(): array;
         
 <h1 id="translate-translatefactory">Class Phalcon\Translate\TranslateFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/translate/translatefactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Translate/TranslateFactory.zep)
 
 | Namespace  | Phalcon\Translate |
 | Uses       | Phalcon\Config, Phalcon\Factory\AbstractFactory, Phalcon\Helper\Arr, Phalcon\Translate\Adapter\AdapterInterface |
@@ -565,7 +565,7 @@ AdapterFactory constructor.
 ```php
 public function load( mixed $config ): mixed;
 ```
-Factory to create an instace from a Config object
+Factory to create an instance from a Config object
 
 
 ```php

--- a/en/api/phalcon_url.md
+++ b/en/api/phalcon_url.md
@@ -11,7 +11,7 @@ title: 'Phalcon\Url'
         
 <h1 id="url">Class Phalcon\Url</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/url.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Url.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\AbstractInjectionAware, Phalcon\Mvc\RouterInterface, Phalcon\Mvc\Router\RouteInterface, Phalcon\Url\Exception, Phalcon\Url\UrlInterface |
@@ -179,7 +179,7 @@ $url->setStaticBaseUri("/invo/");
         
 <h1 id="url-exception">Class Phalcon\Url\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/url/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Url/Exception.zep)
 
 | Namespace  | Phalcon\Url |
 | Extends    | \Phalcon\Exception |
@@ -192,7 +192,7 @@ Exceptions thrown in Phalcon\Url will use this class
         
 <h1 id="url-urlinterface">Interface Phalcon\Url\UrlInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/url/urlinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Url/UrlInterface.zep)
 
 | Namespace  | Phalcon\Url |
 

--- a/en/api/phalcon_validation.md
+++ b/en/api/phalcon_validation.md
@@ -48,7 +48,7 @@ title: 'Phalcon\Validation'
         
 <h1 id="validation">Class Phalcon\Validation</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation.zep)
 
 | Namespace  | Phalcon |
 | Uses       | Phalcon\Di\DiInterface, Phalcon\Di\Injectable, Phalcon\Filter\FilterInterface, Phalcon\Messages\MessageInterface, Phalcon\Messages\Messages, Phalcon\Validation\ValidationInterface, Phalcon\Validation\Exception, Phalcon\Validation\ValidatorInterface, Phalcon\Validation\AbstractCombinedFieldsValidator |
@@ -209,7 +209,7 @@ Internal validations, if it returns true, then skip the current validator
         
 <h1 id="validation-abstractcombinedfieldsvalidator">Abstract Class Phalcon\Validation\AbstractCombinedFieldsValidator</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/abstractcombinedfieldsvalidator.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/AbstractCombinedFieldsValidator.zep)
 
 | Namespace  | Phalcon\Validation |
 | Extends    | AbstractValidator |
@@ -220,7 +220,7 @@ This is a base class for combined fields validators
         
 <h1 id="validation-abstractvalidator">Abstract Class Phalcon\Validation\AbstractValidator</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/abstractvalidator.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/AbstractValidator.zep)
 
 | Namespace  | Phalcon\Validation |
 | Uses       | Phalcon\Collection, Phalcon\Helper\Arr, Phalcon\Messages\Message, Phalcon\Validation |
@@ -341,7 +341,7 @@ Prepares a label for the field.
         
 <h1 id="validation-abstractvalidatorcomposite">Abstract Class Phalcon\Validation\AbstractValidatorComposite</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/abstractvalidatorcomposite.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/AbstractValidatorComposite.zep)
 
 | Namespace  | Phalcon\Validation |
 | Uses       | Phalcon\Validation |
@@ -376,7 +376,7 @@ Executes the validation
         
 <h1 id="validation-exception">Class Phalcon\Validation\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Exception.zep)
 
 | Namespace  | Phalcon\Validation |
 | Extends    | \Phalcon\Exception |
@@ -387,7 +387,7 @@ Exceptions thrown in Phalcon\Validation\* classes will use this class
         
 <h1 id="validation-validationinterface">Interface Phalcon\Validation\ValidationInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validationinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/ValidationInterface.zep)
 
 | Namespace  | Phalcon\Validation |
 | Uses       | Phalcon\Di\Injectable, Phalcon\Messages\MessageInterface, Phalcon\Messages\Messages |
@@ -488,7 +488,7 @@ Validate a set of data according to a set of rules
         
 <h1 id="validation-validator-alnum">Class Phalcon\Validation\Validator\Alnum</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/alnum.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Alnum.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -546,7 +546,7 @@ Executes the validation
         
 <h1 id="validation-validator-alpha">Class Phalcon\Validation\Validator\Alpha</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/alpha.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Alpha.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -604,7 +604,7 @@ Executes the validation
         
 <h1 id="validation-validator-between">Class Phalcon\Validation\Validator\Between</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/between.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Between.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -673,7 +673,7 @@ Executes the validation
         
 <h1 id="validation-validator-callback">Class Phalcon\Validation\Validator\Callback</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/callback.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Callback.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\ValidatorInterface, Phalcon\Validation\AbstractValidator |
@@ -741,7 +741,7 @@ Executes the validation
         
 <h1 id="validation-validator-confirmation">Class Phalcon\Validation\Validator\Confirmation</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/confirmation.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Confirmation.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Exception, Phalcon\Validation\AbstractValidator |
@@ -810,7 +810,7 @@ Compare strings
         
 <h1 id="validation-validator-creditcard">Class Phalcon\Validation\Validator\CreditCard</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/creditcard.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/CreditCard.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -868,7 +868,7 @@ Executes the validation
         
 <h1 id="validation-validator-date">Class Phalcon\Validation\Validator\Date</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/date.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Date.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | DateTime, Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -931,7 +931,7 @@ Executes the validation
         
 <h1 id="validation-validator-digit">Class Phalcon\Validation\Validator\Digit</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/digit.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Digit.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -989,7 +989,7 @@ Executes the validation
         
 <h1 id="validation-validator-email">Class Phalcon\Validation\Validator\Email</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/email.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Email.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -1047,7 +1047,7 @@ Executes the validation
         
 <h1 id="validation-validator-exception">Class Phalcon\Validation\Validator\Exception</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/exception.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Exception.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Extends    | \Phalcon\Exception |
@@ -1059,7 +1059,7 @@ class
         
 <h1 id="validation-validator-exclusionin">Class Phalcon\Validation\Validator\ExclusionIn</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/exclusionin.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/ExclusionIn.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator, Phalcon\Validation\Exception |
@@ -1128,7 +1128,7 @@ Executes the validation
         
 <h1 id="validation-validator-file">Class Phalcon\Validation\Validator\File</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Helper\Arr, Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidatorComposite, Phalcon\Validation\Validator\File\MimeType, Phalcon\Validation\Validator\File\Resolution\Equal, Phalcon\Validation\Validator\File\Resolution\Max, Phalcon\Validation\Validator\File\Resolution\Min, Phalcon\Validation\Validator\File\Size\Equal, Phalcon\Validation\Validator\File\Size\Max, Phalcon\Validation\Validator\File\Size\Min |
@@ -1212,7 +1212,7 @@ Constructor
         
 <h1 id="validation-validator-file-abstractfile">Abstract Class Phalcon\Validation\Validator\File\AbstractFile</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/abstractfile.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/AbstractFile.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -1359,7 +1359,7 @@ public function setMessageValid( $messageValid )
         
 <h1 id="validation-validator-file-mimetype">Class Phalcon\Validation\Validator\File\MimeType</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/mimetype.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/MimeType.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Exception |
@@ -1433,13 +1433,13 @@ Executes the validation
         
 <h1 id="validation-validator-file-resolution-equal">Class Phalcon\Validation\Validator\File\Resolution\Equal</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/resolution/equal.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/Resolution/Equal.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File\Resolution |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Validator\File\AbstractFile |
 | Extends    | AbstractFile |
 
-Checks if a file has the rigth resolution
+Checks if a file has the right resolution
 
 ```php
 use Phalcon\Validation;
@@ -1496,13 +1496,13 @@ Executes the validation
         
 <h1 id="validation-validator-file-resolution-max">Class Phalcon\Validation\Validator\File\Resolution\Max</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/resolution/max.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/Resolution/Max.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File\Resolution |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Validator\File\AbstractFile |
 | Extends    | AbstractFile |
 
-Checks if a file has the rigth resolution
+Checks if a file has the right resolution
 
 ```php
 use Phalcon\Validation;
@@ -1564,13 +1564,13 @@ Executes the validation
         
 <h1 id="validation-validator-file-resolution-min">Class Phalcon\Validation\Validator\File\Resolution\Min</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/resolution/min.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/Resolution/Min.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File\Resolution |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Validator\File\AbstractFile |
 | Extends    | AbstractFile |
 
-Checks if a file has the rigth resolution
+Checks if a file has the right resolution
 
 ```php
 use Phalcon\Validation;
@@ -1632,7 +1632,7 @@ Executes the validation
         
 <h1 id="validation-validator-file-size-equal">Class Phalcon\Validation\Validator\File\Size\Equal</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/size/equal.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/Size/Equal.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File\Size |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Validator\File\AbstractFile |
@@ -1673,7 +1673,7 @@ $validator->add(
                 "anotherFile" => true,
             ],
             "message" => [
-                "file"        => "file does not have the rigth filesize",
+                "file"        => "file does not have the right filesize",
                 "anotherFile" => "anotherFile wrong filesize (4MB)",
             ],
         ]
@@ -1700,7 +1700,7 @@ Executes the validation
         
 <h1 id="validation-validator-file-size-max">Class Phalcon\Validation\Validator\File\Size\Max</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/size/max.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/Size/Max.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File\Size |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Validator\File\AbstractFile |
@@ -1768,7 +1768,7 @@ Executes the validation
         
 <h1 id="validation-validator-file-size-min">Class Phalcon\Validation\Validator\File\Size\Min</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/file/size/min.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/File/Size/Min.zep)
 
 | Namespace  | Phalcon\Validation\Validator\File\Size |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\Validator\File\AbstractFile |
@@ -1836,7 +1836,7 @@ Executes the validation
         
 <h1 id="validation-validator-identical">Class Phalcon\Validation\Validator\Identical</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/identical.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Identical.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -1899,7 +1899,7 @@ Executes the validation
         
 <h1 id="validation-validator-inclusionin">Class Phalcon\Validation\Validator\InclusionIn</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/inclusionin.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/InclusionIn.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator, Phalcon\Validation\Exception |
@@ -1962,7 +1962,7 @@ Executes the validation
         
 <h1 id="validation-validator-ip">Class Phalcon\Validation\Validator\Ip</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/ip.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Ip.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Validation, Phalcon\Validation\AbstractValidator, Phalcon\Messages\Message |
@@ -2043,7 +2043,7 @@ Executes the validation
         
 <h1 id="validation-validator-numericality">Class Phalcon\Validation\Validator\Numericality</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/numericality.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Numericality.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -2101,7 +2101,7 @@ Executes the validation
         
 <h1 id="validation-validator-presenceof">Class Phalcon\Validation\Validator\PresenceOf</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/presenceof.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/PresenceOf.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -2159,7 +2159,7 @@ Executes the validation
         
 <h1 id="validation-validator-regex">Class Phalcon\Validation\Validator\Regex</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/regex.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Regex.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -2222,7 +2222,7 @@ Executes the validation
         
 <h1 id="validation-validator-stringlength">Class Phalcon\Validation\Validator\StringLength</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/stringlength.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/StringLength.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation\AbstractValidator, Phalcon\Validation\AbstractValidatorComposite, Phalcon\Validation\Validator\StringLength\Max, Phalcon\Validation\Validator\StringLength\Min, Phalcon\Validation\Exception |
@@ -2231,7 +2231,7 @@ Executes the validation
 Validates that a string has the specified maximum and minimum constraints
 The test is passed if for a string's length L, min<=L<=max, i.e. L must
 be at least min, and at most max.
-Since Phalcon v4.0 this valitor works like a container
+Since Phalcon v4.0 this validator works like a container
 
 ```php
 use Phalcon\Validation;
@@ -2301,7 +2301,7 @@ Constructor
         
 <h1 id="validation-validator-stringlength-max">Class Phalcon\Validation\Validator\StringLength\Max</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/stringlength/max.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/StringLength/Max.zep)
 
 | Namespace  | Phalcon\Validation\Validator\StringLength |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator, Phalcon\Validation\Exception |
@@ -2371,7 +2371,7 @@ Executes the validation
         
 <h1 id="validation-validator-stringlength-min">Class Phalcon\Validation\Validator\StringLength\Min</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/stringlength/min.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/StringLength/Min.zep)
 
 | Namespace  | Phalcon\Validation\Validator\StringLength |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator, Phalcon\Validation\Exception |
@@ -2441,7 +2441,7 @@ Executes the validation
         
 <h1 id="validation-validator-uniqueness">Class Phalcon\Validation\Validator\Uniqueness</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/uniqueness.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Uniqueness.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Mvc\Model, Phalcon\Mvc\ModelInterface, Phalcon\Validation, Phalcon\Validation\AbstractCombinedFieldsValidator, Phalcon\Validation\Exception |
@@ -2555,7 +2555,7 @@ Uniqueness method used for model
         
 <h1 id="validation-validator-url">Class Phalcon\Validation\Validator\Url</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validator/url.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/Validator/Url.zep)
 
 | Namespace  | Phalcon\Validation\Validator |
 | Uses       | Phalcon\Messages\Message, Phalcon\Validation, Phalcon\Validation\AbstractValidator |
@@ -2613,7 +2613,7 @@ Executes the validation
         
 <h1 id="validation-validatorcompositeinterface">Interface Phalcon\Validation\ValidatorCompositeInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validatorcompositeinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/ValidatorCompositeInterface.zep)
 
 | Namespace  | Phalcon\Validation |
 | Uses       | Phalcon\Validation |
@@ -2638,7 +2638,7 @@ Executes the validation
         
 <h1 id="validation-validatorfactory">Class Phalcon\Validation\ValidatorFactory</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validatorfactory.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/ValidatorFactory.zep)
 
 | Namespace  | Phalcon\Validation |
 | Uses       | Phalcon\Factory\AbstractFactory, Phalcon\Factory\ValidatorInterface, Phalcon\Helper\Arr |
@@ -2674,7 +2674,7 @@ protected function getAdapters(): array;
         
 <h1 id="validation-validatorinterface">Interface Phalcon\Validation\ValidatorInterface</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/validation/validatorinterface.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Validation/ValidatorInterface.zep)
 
 | Namespace  | Phalcon\Validation |
 | Uses       | Phalcon\Collection, Phalcon\Validation |
@@ -2720,7 +2720,7 @@ Checks if an option is defined
 ```php
 public function setTemplate( string $template ): ValidatorInterface;
 ```
-   Set a new temlate message
+   Set a new template message
    
    @return ValidatorInterface
    

--- a/en/api/phalcon_version.md
+++ b/en/api/phalcon_version.md
@@ -9,7 +9,7 @@ title: 'Phalcon\Version'
         
 <h1 id="version">Class Phalcon\Version</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/version.zep)
+[Source on GitHub](https://github.com/phalcon/cphalcon/tree/v{{ page.version }}.0/phalcon/Version.zep)
 
 | Namespace  | Phalcon |
 


### PR DESCRIPTION
#2643

```php
<?php

foreach ( glob('*.md') as $file ) {
	$origContent = file_get_contents($file);

	$newContent = preg_replace_callback(
		'@(<h1[^>]+>[^<]+P(halcon[^<]+)</h1>\s+\[Source on GitHub\])\((https://github.com/phalcon/cphalcon/[^\)]+)/phalcon/[^\)]+\.zep\)@',
		function($m) {
			return $m[1] . '(' . $m[3] . '/p' . str_replace('\\', '/', $m[2]) . '.zep)';
		},
		$origContent
	);

	if ( $origContent !== $newContent ) {
		file_put_contents($file, $newContent);
	}
}
````