### PR TITLE
Fixed typos and bad call to Enum constant

### DIFF
--- a/en/api/phalcon_db.md
+++ b/en/api/phalcon_db.md
@@ -68,10 +68,10 @@ try {
     );
 
     $result = $connection->query(
-        "SELECTFROM robots LIMIT 5"
+        "SELECT * FROM robots LIMIT 5"
     );
 
-    $result->setFetchMode(Enum::FETCH_NUM);
+    $result->setFetchMode(Db\Enum::FETCH_NUM);
 
     while ($robot = $result->fetch()) {
         print_r($robot);
@@ -333,7 +333,7 @@ Dumps the complete result of a query into an array
 ```php
 // Getting all robots with associative indexes only
 $robots = $connection->fetchAll(
-    "SELECTFROM robots",
+    "SELECT * FROM robots",
     \Phalcon\Db\Enum::FETCH_ASSOC
 );
 
@@ -343,7 +343,7 @@ foreach ($robots as $robot) {
 
  // Getting all robots that contains word "robot" withing the name
 $robots = $connection->fetchAll(
-    "SELECTFROM robots WHERE name LIKE :name",
+    "SELECT * FROM robots WHERE name LIKE :name",
     \Phalcon\Db\Enum::FETCH_ASSOC,
     [
         "name" => "%robot%",
@@ -381,12 +381,12 @@ Returns the first row in a SQL query result
 
 ```php
 // Getting first robot
-$robot = $connection->fetchOne("SELECTFROM robots");
+$robot = $connection->fetchOne("SELECT * FROM robots");
 print_r($robot);
 
 // Getting first robot with associative indexes only
 $robot = $connection->fetchOne(
-    "SELECTFROM robots",
+    "SELECT * FROM robots",
     \Phalcon\Db\Enum::FETCH_ASSOC
 );
 print_r($robot);
@@ -569,7 +569,7 @@ public function limit( string $sqlQuery, int $number ): string;
 Appends a LIMIT clause to $sqlQuery argument
 
 ```php
-echo $connection->limit("SELECTFROM robots", 5);
+echo $connection->limit("SELECT * FROM robots", 5);
 ```
 
 
@@ -1322,7 +1322,7 @@ Converts bound parameters such as :name: or ?1 into PDO bind params ?
 ```php
 print_r(
     $connection->convertBoundParams(
-        "SELECTFROM robots WHERE name = :name:",
+        "SELECT * FROM robots WHERE name = :name:",
         [
             "Bender",
         ]
@@ -1375,7 +1375,7 @@ starting from zero
 use Phalcon\Db\Column;
 
 $statement = $db->prepare(
-    "SELECTFROM robots WHERE name = :name"
+    "SELECT * FROM robots WHERE name = :name"
 );
 
 $result = $connection->executePrepared(
@@ -1457,7 +1457,7 @@ Returns a PDO prepared statement to be executed with 'executePrepared'
 use Phalcon\Db\Column;
 
 $statement = $db->prepare(
-    "SELECTFROM robots WHERE name = :name"
+    "SELECT * FROM robots WHERE name = :name"
 );
 
 $result = $connection->executePrepared(
@@ -1482,11 +1482,11 @@ returning rows
 ```php
 // Querying data
 $resultset = $connection->query(
-    "SELECTFROM robots WHERE type = 'mechanical'"
+    "SELECT * FROM robots WHERE type = 'mechanical'"
 );
 
 $resultset = $connection->query(
-    "SELECTFROM robots WHERE type = ?",
+    "SELECT * FROM robots WHERE type = ?",
     [
         "mechanical",
     ]
@@ -2312,9 +2312,9 @@ public function forUpdate( string $sqlQuery ): string;
 Returns a SQL modified with a FOR UPDATE clause
 
 ```php
-$sql = $dialect->forUpdate("SELECTFROM robots");
+$sql = $dialect->forUpdate("SELECT * FROM robots");
 
-echo $sql; // SELECTFROM robots FOR UPDATE
+echo $sql; // SELECT * FROM robots FOR UPDATE
 ```
 
 
@@ -2364,15 +2364,15 @@ public function limit( string $sqlQuery, mixed $number ): string;
 Generates the SQL for LIMIT clause
 
 ```php
-// SELECTFROM robots LIMIT 10
+// SELECT * FROM robots LIMIT 10
 echo $dialect->limit(
-    "SELECTFROM robots",
+    "SELECT * FROM robots",
     10
 );
 
-// SELECTFROM robots LIMIT 10 OFFSET 50
+// SELECT * FROM robots LIMIT 10 OFFSET 50
 echo $dialect->limit(
-    "SELECTFROM robots",
+    "SELECT * FROM robots",
     [10, 50]
 );
 ```
@@ -2725,9 +2725,9 @@ public function sharedLock( string $sqlQuery ): string;
 Returns a SQL modified with a LOCK IN SHARE MODE clause
 
 ```php
-$sql = $dialect->sharedLock("SELECTFROM robots");
+$sql = $dialect->sharedLock("SELECT * FROM robots");
 
-echo $sql; // SELECTFROM robots LOCK IN SHARE MODE
+echo $sql; // SELECT * FROM robots LOCK IN SHARE MODE
 ```
 
 
@@ -4043,7 +4043,7 @@ Gets the schema where referenced table is
 Encapsulates the resultset internals
 
 ```php
-$result = $connection->query("SELECTFROM robots ORDER BY name");
+$result = $connection->query("SELECT * FROM robots ORDER BY name");
 
 $result->setFetchMode(
     \Phalcon\Db\Enum::FETCH_NUM
@@ -4104,7 +4104,7 @@ certain row
 
 ```php
 $result = $connection->query(
-    "SELECTFROM robots ORDER BY name"
+    "SELECT * FROM robots ORDER BY name"
 );
 
 // Move to third row on result
@@ -4131,7 +4131,7 @@ or FALSE if there are no more rows. This method is affected by the active
 fetch flag set using `Phalcon\Db\Result\Pdo::setFetchMode()`
 
 ```php
-$result = $connection->query("SELECTFROM robots ORDER BY name");
+$result = $connection->query("SELECT * FROM robots ORDER BY name");
 
 $result->setFetchMode(
     \Phalcon\Enum::FETCH_OBJ
@@ -4152,7 +4152,7 @@ This method is affected by the active fetch flag set using
 
 ```php
 $result = $connection->query(
-    "SELECTFROM robots ORDER BY name"
+    "SELECT * FROM robots ORDER BY name"
 );
 
 $robots = $result->fetchAll();
@@ -4167,7 +4167,7 @@ if there are no more rows. This method is affected by the active fetch
 flag set using `Phalcon\Db\Result\Pdo::setFetchMode()`
 
 ```php
-$result = $connection->query("SELECTFROM robots ORDER BY name");
+$result = $connection->query("SELECT * FROM robots ORDER BY name");
 
 $result->setFetchMode(
     \Phalcon\Enum::FETCH_NUM
@@ -4192,7 +4192,7 @@ Gets number of rows returned by a resultset
 
 ```php
 $result = $connection->query(
-    "SELECTFROM robots ORDER BY name"
+    "SELECT * FROM robots ORDER BY name"
 );
 
 echo "There are ", $result->numRows(), " rows in the resultset";
@@ -4294,5 +4294,4 @@ Gets number of rows returned by a resultset
 public function setFetchMode( int $fetchMode ): bool;
 ```
 Changes the fetching mode affecting Phalcon\Db\Result\Pdo::fetch()
-
 


### PR DESCRIPTION
Changed 25 instances of "SELECTFROM" to "SELECT * FROM"
Fixed a wrong call to Phalcon\Db\Enum constant