### PR TITLE
Fixed last instance of "SELECTFROM" in docs/api

### DIFF
--- a/en/api/phalcon_mvc.md
+++ b/en/api/phalcon_mvc.md
@@ -5702,7 +5702,7 @@ use Phalcon\Mvc\Model\Transaction;
 // $di needs to have the service "db" registered for this to work
 $di = Phalcon\Di\FactoryDefault::getDefault();
 
-$phql = 'SELECTFROM robot';
+$phql = 'SELECT * FROM robot';
 
 $myTransaction = new Transaction($di);
 $myTransaction->begin();


### PR DESCRIPTION
Checked all the docs for the "SELECTFROM" typo, this is the last occurrence.