### PR TITLE
Corrected typo in SELECT query

### DIFF
--- a/en/tutorial-rest.md
+++ b/en/tutorial-rest.md
@@ -317,7 +317,7 @@ $app->get(
     '/api/robots/{id:[0-9]+}',
     function ($id) use ($app) {
         $phql = 'SELECT * '
-              . 'FROM MyApp\ModelsRobots '
+              . 'FROM MyApp\Models\Robots '
               . 'WHERE id = :id:'
         ;
 


### PR DESCRIPTION
There was a typo in the REST tutorial that rendered the sample query non-functional