### PR TITLE
Wrong object symbol $di

### DIFF
--- a/en/tutorial-basic.md
+++ b/en/tutorial-basic.md
@@ -480,7 +480,7 @@ In order to use a database connection and subsequently access data through our m
 
 use Phalcon\Db\Adapter\Pdo\Mysql;
 
-$di->set(
+$container->set(
     'db',
     function () {
         return new Mysql(


### PR DESCRIPTION
Changed `$di` to `$container` to match the rest of the tutorial.