### PR TITLE
FIX: apcu is not opcode caching

### DIFF
--- a/en/performance.md
+++ b/en/performance.md
@@ -13,7 +13,7 @@ keywords: 'performance, profiling, xdebug, xhprof, yslow, bytecode'
 A poorly written application will always have poor performance. A very common way for developers to increase the performance of their application is:
 
 > just throw more hardware to it
-{: .alert .alert-info } 
+{: .alert .alert-info }
 
 The problem with the above approach is two fold. For starters, in most cases the owner is the one that will incur the additional costs. The second issue is that there comes a time that one can no longer upgrade the hardware and will have to resort to load balancers, docker swarms etc. which will skyrocket costs.
 
@@ -31,18 +31,18 @@ and many more. In this article we will try to highlight some scenarios that coul
 {: .alert .alert-danger }
 
 ## Server
-[Profiling][profiling] is a form of dynamic application analysis that offers metrics regarding your application. Profiling offers the real picture on what is really going on at any given time in your application, and thus guide you to areas where you application needs attention. Profiling should be continuous in a production application. 
+[Profiling][profiling] is a form of dynamic application analysis that offers metrics regarding your application. Profiling offers the real picture on what is really going on at any given time in your application, and thus guide you to areas where you application needs attention. Profiling should be continuous in a production application.
 
-It does have an overhead so that has to be taken into account. The most verbose profiling happens on every request but it will all depend on your traffic. We certainly do not want to increase the load on the server just because we are profiling the application. A common way of profiling is one request per 100 or one per 1,000. After a while you will have enough data to draw conclusions as to where slowdowns occur, why peaks occurred etc. 
+It does have an overhead so that has to be taken into account. The most verbose profiling happens on every request but it will all depend on your traffic. We certainly do not want to increase the load on the server just because we are profiling the application. A common way of profiling is one request per 100 or one per 1,000. After a while you will have enough data to draw conclusions as to where slowdowns occur, why peaks occurred etc.
  
 ### XDebug
-[XDebug][xdebug] offers a very handy profiler right out of the box. All you have to do is install the extension and enable profiling in your `php.ini`: 
+[XDebug][xdebug] offers a very handy profiler right out of the box. All you have to do is install the extension and enable profiling in your `php.ini`:
 
 ```ini
 xdebug.profiler_enable = On
 ```
 
-Using a tool such as [Webgrind][webgrind] will allow you to connect to [XDebug][xdebug] and get very valuable information as to what is going on with your code. [Webgrind][webgrind] offers statistics on which methods are slower than others and other statistics. 
+Using a tool such as [Webgrind][webgrind] will allow you to connect to [XDebug][xdebug] and get very valuable information as to what is going on with your code. [Webgrind][webgrind] offers statistics on which methods are slower than others and other statistics.
 
 ### Xhprof
 [Xhprof][xhprof] is another extension to profile PHP applications. To enable it, all you need is to add the following line to the start of the bootstrap file:
@@ -106,14 +106,30 @@ A relatively easy fix for increasing client performance is to set the correct he
 ## PHP
 PHP is becoming faster with every new version. Using the latest version improves the performance of your applications and also of Phalcon.
 
-## Bytecode Cache
-[APCu][apcu] as many other bytecode caches helps applications reduce the overhead of read, tokenize and parse PHP files in each request. Once the extension is installed use the following setting to enable APC:
+### Bytecode Cache
+[OPcache][opcache] as many other bytecode caches helps applications reduce the overhead of read, tokenize and parse PHP files in each request. The interpreted results are kept in
+RAM between requests as long as PHP runs as fcgi (fpm) or mod_php. OPcache is bundled with php starting 5.5.0. To check if it is activated, look for the following entry in php.ini:
+
+```ini
+opcache.enable = On
+opcache.memory_consumption = 128    ;default
+```
+Furthermore, the amount of memory available for opcode caching needs to be enough to hold all files of your applications. The default of 128MB is usually enough for even larger codebases.
+
+### Serverside cache
+[APCu][apcu] can be used to cache the results of computational expensive operations or otherwise slow data sources like webservices with high latency. What makes a result cacheable
+is another topic, as a rule of thumb: the operations needs to be executed often and yield identical results. Make sure to measure through profiling
+that the optimizations actually improved execution time.
 
 ```ini
 apc.enabled = On
+apc.shm_size = 32M  ;default
 ```
 
-Ensuring that `opcache` is also enabled will also help.
+As with the aforementioned opcache, make sure, the amount of RAM available suits your application.
+Alternatives to APCu would be [Redis][redis] or [Memcached][memcached] - although they need extra processes running
+on your server or another machine.
+
 
 ## Slow Tasks
 Based on the requirements of your application, there maybe times that you will need to perform long running tasks. Examples of such tasks could be processing a video, optimizing images, sending emails, generating PDF documents etc. These tasks should be processed using background jobs. The usual process is:
@@ -137,8 +153,10 @@ The above is a simplistic view of how a queue service for background processing 
 
 [apcu]: https://php.net/manual/en/book.apcu.php
 [cdn]: https://en.wikipedia.org/wiki/Content_delivery_network
+[memcached]: https://memcached.org/
 [mod_pagespeed]: https://www.modpagespeed.com/
 [nats]: https://nats.io
+[opcache]: https://php.net/manual/en/book.opcache.php
 [profiling]: https://en.wikipedia.org/wiki/Profiling_(computer_programming)
 [rabbitmq]: https://www.rabbitmq.com/
 [redis]: https://redis.io/


### PR DESCRIPTION
APCu is a fork of APC that actually removes the opcache as the Zend Opcache (which was formerly known as Zend Optimizer) is bundled with PHP since 5.5.
APCu provides only the user-cache functions which Zend Opcache does not provide. The user-cache allows storing almost any kind of variable in memory between requests.
I modified the section and split it into an opcache and an apcu part.