### PR TITLE
Error in config documentation

### DIFF
--- a/en/logger.md
+++ b/en/logger.md
@@ -69,12 +69,12 @@ $config = [
     "adapters" => [
         "main"  => [
             "adapter" => "stream",
-            "file"    => "/storage/logs/main.log",
+            "name"    => "/storage/logs/main.log",
             "options" => []
         ],
         "admin" => [
             "adapter" => "stream",
-            "file"    => "/storage/logs/admin.log",
+            "name"    => "/storage/logs/admin.log",
             "options" => []
         ],
     ],


### PR DESCRIPTION
Found an error on documentation, it's minor but it's good to have it right.

based on the source files and version I'm using configuration should be 'name' not 'file' for file name for the adapter.