### PR TITLE
Fixed/corrected documentation on DI & translations

### DIFF
--- a/en/translate.md
+++ b/en/translate.md
@@ -158,7 +158,7 @@ Then we can register it in the Di container, when setting up services during boo
 
 use MyApp\Locale;
 
-$container->set('locale', new Locale());
+$container->set('locale', (new Locale())->getTranslator());
 ```
 
 And now you can access the `Locale` plugin from your controllers and anywhere you need to.


### PR DESCRIPTION
Using only 'new Locale()' doesn't work, since it's only injectable object only, and it doesn't have an `_(..)` methods, it's also done the same with a template sample in the documentation. Maybe it's meant to be used somehow otherwise, but at least as it is now in the sample it's not working.