### PR TITLE
fixed ends of php code syntaxes

### DIFF
--- a/en/routing.md
+++ b/en/routing.md
@@ -30,9 +30,10 @@ $router->add(
 $router->handle(
     $_SERVER["REQUEST_URI"]
 );
-````
+```
 
 ## Constants
+
 There are two constants available for the [Phalcon\Mvc\Router][mvc-router] component that are used to define the position of the route in the processing stack.
 
 - `POSITION_FIRST`
@@ -45,6 +46,7 @@ public function __construct(
     bool $defaultRoutes = true
 )
 ```
+
 Phalcon\Mvc\Router constructor
 
 ```php
@@ -371,8 +373,7 @@ $router->add(
 $router->handle(
     $_SERVER["REQUEST_URI"]
 );
-````
-
+```
 
 The first parameter of the `add()` method is the pattern you want to match and, optionally, the second parameter is a set of paths. In the above example, for the URI `/admin/invoices/list`, the `InvoicesController` will be loaded and the `listAction` will be called. It is important to remember that the router does not execute the controller and action, it only collects this information and then forwards it to the [Phalcon\Mvc\Dispatcher](dispatcher) which executes them.
 
@@ -1008,7 +1009,7 @@ $route->beforeMatch(
     }
 );
 ```
-The above will check if the request has been made with AJAX and return false if it was not
+The above will check if the request has been made with AJAX and return <code>false</code> if it was not
 
 You can create a filter class, to allow you to inject the same functionality in different routes.
 


### PR DESCRIPTION
the ```` syntaxes caused strange block in Crowdin translation.

like this:
![2020-07-17](https://user-images.githubusercontent.com/48115430/87704037-b44b8b80-c7d6-11ea-8ba4-a1b8c9043161.jpg)

and added ```<code>``` block to "false"