### PR TITLE
Assets, minor typo fix for JS addAsset and addAssetByType

### DIFF
--- a/en/assets.md
+++ b/en/assets.md
@@ -205,8 +205,8 @@ class IndexController extends Controller
 
         $js1 = new Js('js/jquery.js');
         $js2 = new Js('js/bootstrap.min.js');
+        
         $this->assets->addAsset($js1);
-
         $this->assets->addAssetByType('js', $js2);
     }
 }

--- a/en/assets.md
+++ b/en/assets.md
@@ -205,9 +205,9 @@ class IndexController extends Controller
 
         $js1 = new Js('js/jquery.js');
         $js2 = new Js('js/bootstrap.min.js');
-        $this->assets->addAsset($css1);
+        $this->assets->addAsset($js1);
 
-        $this->assets->addAssetByType('css', $css2);
+        $this->assets->addAssetByType('js', $js2);
     }
 }
 ```


### PR DESCRIPTION
Hello, here is my first very little contribution about Assets documentation.

Juste a minor typo fix, replacing 
```
$js1 = new Js('js/jquery.js');
$js2 = new Js('js/bootstrap.min.js');

$this->assets->addAsset($css1);
$this->assets->addAssetByType('css', $css2);
}
```
by 
```
$js1 = new Js('js/jquery.js');
$js2 = new Js('js/bootstrap.min.js');

$this->assets->addAsset($js1);
$this->assets->addAssetByType('js', $js2);
```

Hope making more interesting PR in the future ! :) 

Regards,