### PR TITLE
update events responses to use correct func params

### DIFF
--- a/en/events.md
+++ b/en/events.md
@@ -629,7 +629,7 @@ $eventsManager->attach(
     }
 );
 
-$eventsManager->fire('custom:custom', null);
+$eventsManager->fire('custom:custom', $eventsManager, null);
 
 print_r($eventsManager->getResponses());
 ```


### PR DESCRIPTION
fix 1 of the event examples giving wrong example 

credits here: https://github.com/phalcon/cphalcon/issues/15133