### PR TITLE
Removed excess > symbol at the end of the paragraph

### DIFF
--- a/en/response.md
+++ b/en/response.md
@@ -303,7 +303,6 @@ To get the cookies set by the user you can use the `getCookies()` method on the 
 
 ### `SameSite`
 If you are using PHP 7.3 or later you can set the `SameSite` as an element to the `options` array (last parameter of the constructor) or by using `setOptions()`. It is your responsibility to assign a valid value for `SameSite` (such as `Strict`, `Lax` etc.)
->
 
 ```php
 <?php


### PR DESCRIPTION
Removed excess > symbol at the end of the paragraph