### PR TITLE
docs(db-models-cache.md): class name in cache key

### DIFF
--- a/en/db-models-cache.md
+++ b/en/db-models-cache.md
@@ -203,7 +203,7 @@ class Invoices extends Model
 
     protected static function generateCacheKey(array $parameters)
     {
-        $uniqueKey = [];
+        $uniqueKey = [Static::class];
 
         foreach ($parameters as $key => $value) {
             if (true === is_scalar($value)) {
@@ -269,7 +269,7 @@ abstract class AbstractCacheable extends Model
 
     protected static function generateCacheKey(array $parameters)
     {
-        $uniqueKey = [];
+        $uniqueKey = [Static::class];
 
         foreach ($parameters as $key => $value) {
             if (true === is_scalar($value)) {
@@ -514,7 +514,7 @@ class Invoices extends Model
 
     protected static function generateCacheKey(array $parameters)
     {
-        $uniqueKey = [];
+        $uniqueKey = [Static::class];
 
         foreach ($parameters as $key => $value) {
             if (true === is_scalar($value)) {
@@ -587,7 +587,7 @@ class Invoices extends Model
 
     protected static function generateCacheKey(array $parameters)
     {
-        $uniqueKey = [];
+        $uniqueKey = [Static::class];
 
         foreach ($parameters as $key => $value) {
             if (true === is_scalar($value)) {


### PR DESCRIPTION
Not having the model name in the key can load a cached result from another model.

Well, at least in phalcon 3.4 - https://docs.phalcon.io/3.4/en/db-models-cache