### PR TITLE
Update application-cli.md

### DIFF
--- a/en/application-cli.md
+++ b/en/application-cli.md
@@ -36,7 +36,7 @@ declare(strict_types=1);
 use Exception;
 use Phalcon\Cli\Console;
 use Phalcon\Cli\Dispatcher;
-use Phalcon\Cli\Exception as PhalconException;
+use Phalcon\Cli\Console\Exception as PhalconException;
 use Phalcon\Di\FactoryDefault\Cli as CliDI;
 use Phalcon\Loader\Loader;
 use Throwable;


### PR DESCRIPTION
`Phalcon\Cli\Exception` doesn't exist.  Replaced with `Phalcon\Cli\Console\Exception`.