### PR TITLE
Documentaion on Config Service.

### DIFF
--- a/en/config.md
+++ b/en/config.md
@@ -90,7 +90,7 @@ The Config Factory also offers the `load` method, which accepts a string or an a
 ```php
 <?php
 
-use Phalcon\Cache\CacheFactory;
+use Phalcon\Config\ConfigFactory;
 
 $fileName = '/app/storage/config.php';
 $factory  = new ConfigFactory();
@@ -116,7 +116,7 @@ the `load` function will create an [Ini][ini] config object:
 ```php
 <?php
 
-use Phalcon\Cache\CacheFactory;
+use Phalcon\Config\ConfigFactory;
 
 $fileName = '/app/storage/config.ini';
 $factory  = new ConfigFactory();


### PR DESCRIPTION
update Phalcon\Cache\CacheFactory; to Phalcon\Config\ConfigFactory;

for instance:

```php
use Phalcon\Cache\CacheFactory;
$fileName = '/app/storage/config.php';
$factory  = new ConfigFactory();

$options = [
    'adapter'  => 'php',
    'filePath' => $fileName,
];

$config = $factory->load($options);
```
the namespace should be  _**Phalcon\Config\ConfigFactory;**_