### PR TITLE
Method name fixed

### DIFF
--- a/en/application.md
+++ b/en/application.md
@@ -393,7 +393,7 @@ use Phalcon\Mvc\Dispatcher;
 use Phalcon\Mvc\View;
 
 $loader = new Loader();
-$loader->registerNamespaces(
+$loader->setNamespaces(
     [
         'Single\Controllers' => '../apps/controllers/',
         'Single\Models'      => '../apps/models/',
@@ -482,7 +482,7 @@ class Module implements ModuleDefinitionInterface
     )
     {
         $loader = new Loader();
-        $loader->registerNamespaces(
+        $loader->setNamespaces(
             [
                 'Multi\Back\Controllers' => '../apps/back/controllers/',
                 'Multi\Back\Models'      => '../apps/back/models/',


### PR DESCRIPTION
Method name changed in 5.0: `registerNamespaces()` > `setNamespaces()`.