### PR TITLE
Update forms.md

### DIFF
--- a/en/forms.md
+++ b/en/forms.md
@@ -696,14 +696,14 @@ These elements use the [Phalcon\Html\TagFactory][tagfactory] component transpare
 
 The [Phalcon\Forms\Element\Select][forms-element-select] supports the `useEmpty` option to enable the use of a blank element within the list of available options. The options `emptyText` and` emptyValue` are optional, which allow you to customize, respectively, the text and the value of the empty element
  
-You can also create your own elements by extending the [Phalcon\Forms\Element\ElementInterface][forms-element-elementinterface] interface.
+You can also create your own elements by extending the [Phalcon\Forms\Element\AbstractElement](https://docs.phalcon.io/5.0/en/api/phalcon_forms#forms-element-abstractelement) abstract class.
 
 ```php
 <?php
 
-use Phalcon\Forms\Element;
+use Phalcon\Forms\Element\AbstractElement ;
 
-class MyElement extends Element
+class MyElement extends AbstractElement
 {
     public function render($attributes = null)
     {


### PR DESCRIPTION
update out-of-date documentation.

class ```Phalcon\Forms\Element``` does not exist anymore in Phalcon 5.0.